### PR TITLE
add smart gradient accumulation

### DIFF
--- a/train_full_sft.py
+++ b/train_full_sft.py
@@ -53,7 +53,11 @@ def train_epoch(epoch, wandb):
             loss += res.aux_loss
             loss = loss / args.accumulation_steps
 
-        scaler.scale(loss).backward()
+        if (step + 1) % args.accumulation_steps != 0:
+            with model.no_sync():  # Disable DDP gradient synchronization
+                scaler.scale(loss).backward()
+        else:
+            scaler.scale(loss).backward()
 
         if (step + 1) % args.accumulation_steps == 0:
             scaler.unscale_(optimizer)

--- a/train_pretrain.py
+++ b/train_pretrain.py
@@ -53,7 +53,11 @@ def train_epoch(epoch, wandb):
             loss += res.aux_loss
             loss = loss / args.accumulation_steps
 
-        scaler.scale(loss).backward()
+        if (step + 1) % args.accumulation_steps != 0:
+            with model.no_sync():  # Disable DDP gradient synchronization
+                scaler.scale(loss).backward()
+        else:
+            scaler.scale(loss).backward()
 
         if (step + 1) % args.accumulation_steps == 0:
             scaler.unscale_(optimizer)


### PR DESCRIPTION
对于pretrain 和 SFT， 通常使用大一点的梯度累计，所以只在最后一次累计同步梯度能够减少通信开销，加速训练。