### PR TITLE
移除构建输入文本时在开头和末尾重复添加的<s>和</s>

### DIFF
--- a/model/dataset.py
+++ b/model/dataset.py
@@ -35,7 +35,7 @@ class PretrainDataset(Dataset):
         sample = self.samples[index]
 
         # 构建输入文本
-        text = f"{self.tokenizer.bos_token}{str(sample['text'])}{self.tokenizer.eos_token}"
+        text = sample['text']
         encoding = self.tokenizer(
             text,
             max_length=self.max_length,


### PR DESCRIPTION
在预训练阶段，pretrain_hq.jsonl文件中已经用和将句子分割，在dataset.py文件构建输入文本时，再次在头部和尾部添加了和，有重复。

fix #314