### PR TITLE
Stabilize full SFT

### DIFF
--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
         batch_size=args.batch_size,
         pin_memory=True,
         drop_last=False,
-        shuffle=False,
+        shuffle=True,
         num_workers=args.num_workers,
         sampler=train_sampler
     )


### PR DESCRIPTION
When I was full sft the minimind model with sft_512 dataset, it always had some spikes in the loss function. It was caused by the shuffle in the `DataLoader`.

If the data is to be fed in blocks according to file or shard order, when the training encounters sudden changes in template, domain, or sequence length, it may produce a series of spikes.

This is the loss when shuffle is off:
<img width="984" height="561" alt="loss_when_shuffle_off" src="https://github.com/user-attachments/assets/2d0dcb8b-e2c2-4b93-afbe-96d5f4941a0d" />

And now the loss after the shuffle is on:
<img width="989" height="568" alt="loss_after_shuffle_on" src="https://github.com/user-attachments/assets/ae0f60c6-781d-4ab0-b994-68e29111917b" />


