### PR TITLE
fix: attn_forwad when is_causal=True assert attn_mask is None

### DIFF
--- a/model/model_minimind.py
+++ b/model/model_minimind.py
@@ -194,13 +194,7 @@ class Attention(nn.Module):
         )
 
         if self.flash and seq_len > 1 and (attention_mask is None or torch.all(attention_mask == 1)):
-            attn_mask = (
-                None
-                if attention_mask is None
-                else attention_mask.view(bsz, 1, 1, -1).expand(bsz, self.n_local_heads, seq_len, -1).bool()
-            )
-
-            output = F.scaled_dot_product_attention(xq, xk, xv, attn_mask=attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=True)
+            output = F.scaled_dot_product_attention(xq, xk, xv, dropout_p=self.dropout if self.training else 0.0, is_causal=True)
         else:
             scores = (xq @ xk.transpose(-2, -1)) / math.sqrt(self.head_dim)
             scores = scores + torch.triu(


### PR DESCRIPTION
作者你好，在训练更大的Minimind时 ( 约 3B )，发现推理过程中出现了如下错误：

``` bash
  File "minimind/model/model_minimind.py", line 203, in forward
    output = F.scaled_dot_product_attention(xq, xk, xv, attn_mask=attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True
```

查阅 torch.nn.functional.scaled_dot_product_attention 官方文档有如下说明，**当is_causal设置为True时，会检查“assert attn_mask is None”**：
``` python
# Efficient implementation equivalent to the following:
def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
        is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
    L, S = query.size(-2), key.size(-2)
    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
    attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
    if is_causal:
        assert attn_mask is None
        temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
        attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))

    ......
```

参数说明：
<img width="772" height="248" alt="image" src="https://github.com/user-attachments/assets/d4bbdae6-6b16-416a-9bcd-f4e499ca20be" />


经过测试，修改后不会影响不同大小的Minimind运行：
``` bash
# 25M Minimind
xq: torch.Size([1, 8, 2, 64])
xk: torch.Size([1, 8, 2, 64])
xv: torch.Size([1, 8, 2, 64])
attn_mask: torch.Size([1, 8, 2, 2])
attention_mask is None:  False
torch.all(attention_mask == 1):  tensor(True, device='cuda:0')

# 3B Minimind
xq: torch.Size([1, 28, 25, 118])
xk: torch.Size([1, 28, 25, 118])
xv: torch.Size([1, 28, 25, 118])
attn_mask: torch.Size([1, 28, 25, 25])
attention_mask is None:  False
torch.all(attention_mask == 1):  tensor(True, device='cuda:0')
```

疑惑点在于 MiniMind 体量较小时，如 25M 不会出现该错误，他们都运行到了同一位置且 attention_mask 状态相同。考虑是 25M Minimind 模型的序列长度 seq_len=2，因果掩码（下三角矩阵）与全 True 的 attn_mask 效果完全一致（2x2 的下三角矩阵本身就是全 True），此时即使传入 attn_mask，实际计算结果与仅用因果掩码完全相同，可能被 PyTorch 内部优化跳过冲突检查。