### PR TITLE
[fix] Refactor get_lr function to include min_lr calculation

### DIFF
--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -23,7 +23,8 @@ def Logger(content):
 
 
 def get_lr(current_step, total_steps, lr):
-    return lr / 10 + 0.5 * lr * (1 + math.cos(math.pi * current_step / total_steps))
+    min_lr = lr / 10
+    return min_lr + 0.5 * (lr - min_lr) * (1 + math.cos(math.pi * current_step / total_steps))
 
 
 def init_distributed_mode():


### PR DESCRIPTION
这里的退火算法会让参数里的lr的起始值变成原来lr的1.1倍，对@train_utils.py作出如下修改：
def get_lr(current_step, total_steps, lr):
    min_lr = lr / 10
    return min_lr + 0.5 * (lr - min_lr) * (1 + math.cos(math.pi * current_step / total_steps))
