### PR TITLE
Fix DPO loss_mask boundary (include first assistant token)

### DIFF
--- a/dataset/lm_dataset.py
+++ b/dataset/lm_dataset.py
@@ -159,7 +159,7 @@ class DPODataset(Dataset):
                     if input_ids[end:end + len(self.eos_id)] == self.eos_id:
                         break
                     end += 1
-                for j in range(start + 1, min(end + len(self.eos_id) + 1, self.max_length)):
+                for j in range(start, min(end + len(self.eos_id) + 1, self.max_length)):
                     loss_mask[j] = 1
                 i = end + len(self.eos_id) if end < len(input_ids) else len(input_ids)
             else:


### PR DESCRIPTION
Fix off-by-one in generate_loss_mask so the first assistant token contributes to loss in DPO.
Ref Issue #395