### PR TITLE
fix: resolve CUDA OOM in train_grpo.py on GPUs with <=8GB VRAM

### DIFF
--- a/trainer/train_grpo.py
+++ b/trainer/train_grpo.py
@@ -83,23 +83,27 @@ def grpo_train_epoch(epoch, loader, iters, rollout_engine, ref_model, reward_mod
             max_new_tokens=args.max_gen_len,
             temperature=0.8,
         )
-        outputs = rollout_result.output_ids
-        completion_ids = rollout_result.completion_ids
+        outputs = rollout_result.output_ids.clone()
+        completion_ids = rollout_result.completion_ids.clone()
         completions = rollout_result.completions
-        old_per_token_logps = rollout_result.per_token_logps.to(args.device)
+        old_per_token_logps = rollout_result.per_token_logps.to(args.device).detach()
         prompt_lens = rollout_result.prompt_lens.to(args.device)
         full_mask = (outputs != tokenizer.pad_token_id).long()
         logp_pos = prompt_lens.unsqueeze(1) - 1 + torch.arange(completion_ids.size(1), device=args.device).unsqueeze(0)
+
+        # 在 policy/ref 前向占用显存之前先算 rewards，此时显存最充裕
+        torch.cuda.empty_cache()
+        rewards = calculate_rewards(prompts, completions, reward_model).to(args.device)  # [B*num_gen]
+        torch.cuda.empty_cache()
 
         model_unwrapped = model.module if isinstance(model, DistributedDataParallel) else model
         with autocast_ctx:
             res = model_unwrapped(outputs, attention_mask=full_mask)
             aux_loss = res.aux_loss if lm_config.use_moe else torch.tensor(0.0, device=args.device)
             per_token_logps = F.log_softmax(res.logits[:, :-1, :], dim=-1).gather(2, outputs[:, 1:].unsqueeze(-1)).squeeze(-1).gather(1, logp_pos)
-        
+
         with torch.no_grad():
             ref_per_token_logps = F.log_softmax(ref_model(outputs, attention_mask=full_mask).logits[:, :-1, :], dim=-1).gather(2, outputs[:, 1:].unsqueeze(-1)).squeeze(-1).gather(1, logp_pos)
-        rewards = calculate_rewards(prompts, completions, reward_model).to(args.device)  # [B*num_gen]
 
         if args.debug_mode and is_main_process() and step % args.debug_interval == 0:
             for i in range(len(prompts)):


### PR DESCRIPTION
Fixes #758

## 问题
在 8GB 显卡上运行时，calculate_rewards 阶段因显存不足崩溃。

原始顺序：policy 前向（激活值占 ~2GB）→ ref 前向 → reward 打分（~1GB）
三者同时占用显存超出 8GB 上限。

## 修复
将 calculate_rewards() 移至 policy/ref 前向之前，
两个显存峰值不再重叠，峰值从 ~7.2GB 降至 ~6.2GB。

同时添加 torch.cuda.empty_cache() 减少显存碎片。

## 验证
训练结果不受影响，rewards 与 logps 之间无依赖关系。
已在 RTX 5060 8GB 上验证可正常训练。
