### PR TITLE
fix: guard against empty/filtered LLM responses in chat_api.py

### DIFF
--- a/scripts/chat_api.py
+++ b/scripts/chat_api.py
@@ -21,6 +21,8 @@ while True:
         extra_body={"chat_template_kwargs": {"open_thinking": True}, "reasoning_effort": "medium"} # 思考开关
     )
     if not stream:
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         assistant_res = response.choices[0].message.content
         print('[A]: ', assistant_res)
     else:


### PR DESCRIPTION
## What

Add a null check before `response.choices[0].message.content` in the non-streaming path of `scripts/chat_api.py`.

## Why

Two crash vectors exist at `response.choices[0].message.content`:

1. **`IndexError`** — when `choices` is an empty list (network issues, provider-side edge cases returning HTTP 200 with an empty body)
2. **`AttributeError`** — when `choices[0].message` is `None`. Some providers (Gemini via OpenAI-compatible endpoint on PROHIBITED_CONTENT) return HTTP 200 with `message: null` rather than an HTTP error code

## Fix

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
assistant_res = response.choices[0].message.content
```

No behaviour change for well-formed responses.