### PR TITLE
fix: don't char-slice the prompt by max_new_tokens / max_tokens in web_demo & serve_openai_api

### DIFF
--- a/scripts/serve_openai_api.py
+++ b/scripts/serve_openai_api.py
@@ -104,7 +104,7 @@ def parse_response(text):
 
 def generate_stream_response(messages, temperature, top_p, max_tokens, tools=None, open_thinking=False):
     try:
-        new_prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True, tools=tools or None, open_thinking=open_thinking)[-max_tokens:]
+        new_prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True, tools=tools or None, open_thinking=open_thinking)
         inputs = tokenizer(new_prompt, return_tensors="pt", truncation=True).to(device)
 
         queue = Queue()
@@ -190,7 +190,7 @@ async def chat_completions(request: ChatRequest):
                 add_generation_prompt=True,
                 tools=request.tools or None,
                 open_thinking=request.get_open_thinking()
-            )[-request.max_tokens:]
+            )
             inputs = tokenizer(new_prompt, return_tensors="pt", truncation=True).to(device)
             with torch.no_grad():
                 generated_ids = model.generate(

--- a/scripts/web_demo.py
+++ b/scripts/web_demo.py
@@ -339,8 +339,8 @@ def main():
         st.markdown(
             f'<div style="display: flex; justify-content: flex-end;"><div style="display: inline-block; margin: 10px 0; padding: 8px 12px 8px 12px; background-color: #3d4450; border-radius: 22px; color: white;">{prompt}</div></div>',
             unsafe_allow_html=True)
-        messages.append({"role": "user", "content": prompt[-st.session_state.max_new_tokens:]})
-        st.session_state.chat_messages.append({"role": "user", "content": prompt[-st.session_state.max_new_tokens:]})
+        messages.append({"role": "user", "content": prompt})
+        st.session_state.chat_messages.append({"role": "user", "content": prompt})
 
         placeholder = st.empty()
 


### PR DESCRIPTION
## What

When the user sends a message, the prompt is sliced by **character count** using the **generation-length** budget before being given to the model. This corrupts the input in two scripts:

### `scripts/web_demo.py` (lines 342–343)
```python
messages.append({"role": "user", "content": prompt[-st.session_state.max_new_tokens:]})
st.session_state.chat_messages.append({"role": "user", "content": prompt[-st.session_state.max_new_tokens:]})
```
The chat bubble (line 340) renders the **full** `prompt`, but the message stored in history and sent to the model is `prompt[-max_new_tokens:]` — the last *N characters*. So:
- the UI and the model see **different** text, and
- the **beginning** of a long question is silently dropped (the model's input starts mid-sentence).

`max_new_tokens` is the *output* slider (`max_length`, range 256–8192); using it to trim the *input* by characters is unintended.

### `scripts/serve_openai_api.py` (lines 107 and 193)
```python
new_prompt = tokenizer.apply_chat_template(messages, tokenize=False, ...)[-max_tokens:]
```
Same `[-max_tokens:]` slice on the **rendered chat template**. When a client sends a small `max_tokens`, this cuts the template from the front, dropping the system block and slicing mid `<|im_start|>` special-token, so the model receives a malformed prompt.

## Repro (no weights needed — pure string logic)
```python
max_new_tokens = 256
user_prompt = "Please summarize: " + "A"*300 + " in one sentence."
ui_shows   = user_prompt                    # web_demo line 340 renders this
model_gets = user_prompt[-max_new_tokens:]  # lines 342-343 store this
print(ui_shows == model_gets)               # False  -> UI != model
print(model_gets[:20])                       # 'AAAAAAAAAAAAAAAAAAAA' -> instruction lost

templated = "<|im_start|>system\nYou are MiniMind.<|im_end|>\n<|im_start|>user\nHi<|im_end|>\n<|im_start|>assistant\n"
print(templated[-64:].startswith("<|im_start|>system"))  # False -> system block gone
```

## Fix
Store the **full** prompt / template. Input context is already bounded at the **token** level by the existing `tokenizer(new_prompt, return_tensors="pt", truncation=True)` (`model_max_length = 131072`), so no length safeguard is lost — the only change is that the input is no longer corrupted.

After the fix: `UI == model` is `True`, and the chat template is left intact.

---
*AI-assisted contribution; reviewed and tested by me.*
