### PR TITLE
Add on-device QAT training script, optimize the training receipt option make the pretrain 2x faster.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ out
 website/
 docs-minimind/
 .venv/
+checkpoints/
+dataset/
+profile_out/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 out
 website/
 docs-minimind/
+.venv/

--- a/dataset/lm_dataset.py
+++ b/dataset/lm_dataset.py
@@ -56,12 +56,16 @@ class PretrainDataset(Dataset):
 
 
 class SFTDataset(Dataset):
-    def __init__(self, jsonl_path, tokenizer, max_length=1024):
+    def __init__(self, jsonl_path, tokenizer, max_length=1024, subset_size=0, subset_seed=42):
         super().__init__()
         self.tokenizer = tokenizer
         self.max_length = max_length
         features = Features({'conversations': [{'role': Value('string'), 'content': Value('string'), 'reasoning_content': Value('string'), 'tools': Value('string'), 'tool_calls': Value('string')}]})
         self.samples = load_dataset('json', data_files=jsonl_path, split='train', features=features)
+        # QAT / dry-run 用途：shuffle 后 select，避免取前 N 引入 jsonl 顺序偏置
+        # (activation observer 的 running_max 需要看到代表性输入分布)
+        if subset_size and 0 < subset_size < len(self.samples):
+            self.samples = self.samples.shuffle(seed=subset_seed).select(range(subset_size))
         self.bos_id = tokenizer(f'{tokenizer.bos_token}assistant\n', add_special_tokens=False).input_ids
         self.eos_id = tokenizer(f'{tokenizer.eos_token}\n', add_special_tokens=False).input_ids
 

--- a/dataset/lm_dataset.py
+++ b/dataset/lm_dataset.py
@@ -39,7 +39,16 @@ class PretrainDataset(Dataset):
         super().__init__()
         self.tokenizer = tokenizer
         self.max_length = max_length
-        self.samples = load_dataset('json', data_files=data_path, split='train')
+        # data_path 支持三种形式：
+        #   1. 单文件路径 str          → 单 jsonl
+        #   2. 逗号分隔多路径 str      → 从 CLI 传入的多文件混合（"a.jsonl,b.jsonl"）
+        #   3. list[str]              → API 调用直接传列表
+        # 混合场景：1B pretrain 用 SkyPile 25B（raw web）+ minimind pretrain 1.76B（curated Q&A）
+        if isinstance(data_path, str) and ',' in data_path:
+            data_files = [p.strip() for p in data_path.split(',') if p.strip()]
+        else:
+            data_files = data_path
+        self.samples = load_dataset('json', data_files=data_files, split='train')
 
     def __len__(self):
         return len(self.samples)

--- a/model/model_minimind.py
+++ b/model/model_minimind.py
@@ -206,20 +206,24 @@ class MiniMindModel(nn.Module):
         self.register_buffer("freqs_cos", freqs_cos, persistent=False)
         self.register_buffer("freqs_sin", freqs_sin, persistent=False)
 
+    def warmup_rope(self, device=None):
+        """Meta-device init 下 buffer 可能为空，manual 调用重新 precompute。正常 code path 不需要。"""
+        if self.freqs_cos.numel() == 0:
+            freqs_cos, freqs_sin = precompute_freqs_cis(dim=self.config.head_dim, end=self.config.max_position_embeddings, rope_base=self.config.rope_theta, rope_scaling=self.config.rope_scaling)
+            device = device or self.embed_tokens.weight.device
+            self.freqs_cos, self.freqs_sin = freqs_cos.to(device), freqs_sin.to(device)
+
     def forward(self, input_ids, attention_mask=None, past_key_values=None, use_cache=False, **kwargs):
         batch_size, seq_length = input_ids.shape
         if hasattr(past_key_values, 'layers'): past_key_values = None
         past_key_values = past_key_values or [None] * len(self.layers)
         start_pos = past_key_values[0][0].shape[1] if past_key_values[0] is not None else 0
         hidden_states = self.dropout(self.embed_tokens(input_ids))
-        # Lazy recompute of RoPE buffers if they were dropped by transformers>=5.x meta-device init.
-        # Hot path: skipped via cheap python bool (no GPU sync). The original `freqs_cos[0,0]==0`
-        # tensor compare forced a device-to-host sync on every forward.
-        if getattr(self, '_rope_ready', False) is False:
-            if self.freqs_cos.numel() == 0 or bool(self.freqs_cos[0, 0].eq(0).cpu()):
-                freqs_cos, freqs_sin = precompute_freqs_cis(dim=self.config.head_dim, end=self.config.max_position_embeddings, rope_base=self.config.rope_theta, rope_scaling=self.config.rope_scaling)
-                self.freqs_cos, self.freqs_sin = freqs_cos.to(hidden_states.device), freqs_sin.to(hidden_states.device)
-            self._rope_ready = True
+        # RoPE buffers 已在 __init__ 里 precompute + register_buffer；forward 直接切片即可。
+        # (原来这里有 lazy re-compute 兜底 transformers>=5.x meta-device init 掉 buffer 的情况，
+        # 但那段 `bool(freqs_cos[0,0].eq(0).cpu())` 是 torch.compile graph break——每步 forward
+        # 都要在 compiled ↔ eager 间切换 + guard 检查，短 step 下吃掉一半吞吐。如需 meta-init
+        # 兼容，在 model.to(device) 后手动调 warmup_rope() 即可，不要放 forward hot path。)
         position_embeddings = (self.freqs_cos[start_pos:start_pos + seq_length], self.freqs_sin[start_pos:start_pos + seq_length])
         presents = []
         for layer, past_key_value in zip(self.layers, past_key_values):

--- a/model/model_minimind.py
+++ b/model/model_minimind.py
@@ -212,10 +212,14 @@ class MiniMindModel(nn.Module):
         past_key_values = past_key_values or [None] * len(self.layers)
         start_pos = past_key_values[0][0].shape[1] if past_key_values[0] is not None else 0
         hidden_states = self.dropout(self.embed_tokens(input_ids))
-        # Recompute RoPE buffers lost during meta-device init (transformers>=5.x)
-        if self.freqs_cos[0, 0] == 0:
-            freqs_cos, freqs_sin = precompute_freqs_cis(dim=self.config.head_dim, end=self.config.max_position_embeddings, rope_base=self.config.rope_theta, rope_scaling=self.config.rope_scaling)
-            self.freqs_cos, self.freqs_sin = freqs_cos.to(hidden_states.device), freqs_sin.to(hidden_states.device)
+        # Lazy recompute of RoPE buffers if they were dropped by transformers>=5.x meta-device init.
+        # Hot path: skipped via cheap python bool (no GPU sync). The original `freqs_cos[0,0]==0`
+        # tensor compare forced a device-to-host sync on every forward.
+        if getattr(self, '_rope_ready', False) is False:
+            if self.freqs_cos.numel() == 0 or bool(self.freqs_cos[0, 0].eq(0).cpu()):
+                freqs_cos, freqs_sin = precompute_freqs_cis(dim=self.config.head_dim, end=self.config.max_position_embeddings, rope_base=self.config.rope_theta, rope_scaling=self.config.rope_scaling)
+                self.freqs_cos, self.freqs_sin = freqs_cos.to(hidden_states.device), freqs_sin.to(hidden_states.device)
+            self._rope_ready = True
         position_embeddings = (self.freqs_cos[start_pos:start_pos + seq_length], self.freqs_sin[start_pos:start_pos + seq_length])
         presents = []
         for layer, past_key_value in zip(self.layers, past_key_values):

--- a/model/model_minimind.py
+++ b/model/model_minimind.py
@@ -205,6 +205,13 @@ class MiniMindModel(nn.Module):
         freqs_cos, freqs_sin = precompute_freqs_cis(dim=config.head_dim, end=config.max_position_embeddings, rope_base=config.rope_theta, rope_scaling=config.rope_scaling)
         self.register_buffer("freqs_cos", freqs_cos, persistent=False)
         self.register_buffer("freqs_sin", freqs_sin, persistent=False)
+        # gradient checkpointing 标志：True 时 forward 不存 activation，
+        # backward 时重算——省 activation 显存但慢 ~30%。1B + seq=1024 在 80GB 无需，
+        # 但 seq=2048 或 8B+ 模型必须。由 trainer 通过 set_grad_checkpointing() 打开。
+        self.grad_checkpointing = False
+
+    def set_grad_checkpointing(self, enable: bool = True):
+        self.grad_checkpointing = enable
 
     def warmup_rope(self, device=None):
         """Meta-device init 下 buffer 可能为空，manual 调用重新 precompute。正常 code path 不需要。"""
@@ -226,14 +233,25 @@ class MiniMindModel(nn.Module):
         # 兼容，在 model.to(device) 后手动调 warmup_rope() 即可，不要放 forward hot path。)
         position_embeddings = (self.freqs_cos[start_pos:start_pos + seq_length], self.freqs_sin[start_pos:start_pos + seq_length])
         presents = []
+        # gradient checkpointing 与 use_cache=True 不兼容（重算时无法访问 KV cache），
+        # 训练场景一般 use_cache=False，此处兜底 guard 提示。
+        use_ckpt = self.grad_checkpointing and self.training and not use_cache
         for layer, past_key_value in zip(self.layers, past_key_values):
-            hidden_states, present = layer(
-                hidden_states,
-                position_embeddings,
-                past_key_value=past_key_value,
-                use_cache=use_cache,
-                attention_mask=attention_mask
-            )
+            if use_ckpt:
+                # use_reentrant=False 是 torch>=2.1 推荐（旧 reentrant 版本对 DDP/compile 有问题）
+                hidden_states, present = torch.utils.checkpoint.checkpoint(
+                    layer, hidden_states, position_embeddings,
+                    past_key_value, use_cache, attention_mask,
+                    use_reentrant=False,
+                )
+            else:
+                hidden_states, present = layer(
+                    hidden_states,
+                    position_embeddings,
+                    past_key_value=past_key_value,
+                    use_cache=use_cache,
+                    attention_mask=attention_mask
+                )
             presents.append(present)
         hidden_states = self.norm(hidden_states)
         aux_loss = sum([l.mlp.aux_loss for l in self.layers if isinstance(l.mlp, MOEFeedForward)], hidden_states.new_zeros(1).squeeze())

--- a/model/quant.py
+++ b/model/quant.py
@@ -1,0 +1,177 @@
+"""
+W8A8 QAT fake-quantization utilities (pure PyTorch, STE).
+
+- WeightFakeQuant: per-output-channel symmetric int8 on Linear weights.
+- ActFakeQuant:    per-tensor   symmetric int8 on activations, with EMA observer
+                   and a warmup window (collect stats only, no quant in forward).
+- QATLinear:       drop-in nn.Linear replacement that fake-quantizes its input
+                   activation and its weight on every forward.
+- prepare_qat:     in-place swap every nn.Linear in a model with QATLinear,
+                   skipping any module whose qualified name matches `skip_patterns`
+                   (default: lm_head, MoE router `mlp.gate`).
+
+The STE used here zeros gradients for values that saturate (clip-aware STE),
+which is more stable than plain pass-through for low-bit training.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _FakeQuantize(torch.autograd.Function):
+    """round(x/scale + zp) -> clamp -> dequant. Backward: STE inside clip, 0 outside."""
+
+    @staticmethod
+    def forward(ctx, x, scale, zero_point, qmin, qmax):
+        q = torch.round(x / scale + zero_point)
+        q_clamped = q.clamp(qmin, qmax)
+        ctx.save_for_backward((q >= qmin) & (q <= qmax))
+        return (q_clamped - zero_point) * scale
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (mask,) = ctx.saved_tensors
+        return grad_output * mask.to(grad_output.dtype), None, None, None, None
+
+
+def fake_quantize(x, scale, zero_point, qmin, qmax):
+    return _FakeQuantize.apply(x, scale, zero_point, qmin, qmax)
+
+
+class WeightFakeQuant(nn.Module):
+    """Per-output-channel symmetric int8 fake-quant for Linear weight [out, in]."""
+
+    def __init__(self, bits: int = 8):
+        super().__init__()
+        self.bits = bits
+        self.qmax = (1 << (bits - 1)) - 1
+        self.qmin = -(1 << (bits - 1))
+
+    def forward(self, w: torch.Tensor) -> torch.Tensor:
+        max_abs = w.detach().abs().amax(dim=1, keepdim=True).clamp_min(1e-8)
+        scale = (max_abs / self.qmax).to(w.dtype)
+        zp = torch.zeros_like(scale)
+        return fake_quantize(w, scale, zp, self.qmin, self.qmax)
+
+
+class ActFakeQuant(nn.Module):
+    """Per-tensor symmetric int8 fake-quant with EMA min/max observer + warmup."""
+
+    def __init__(self, bits: int = 8, momentum: float = 0.99, observer_steps: int = 200):
+        super().__init__()
+        self.bits = bits
+        self.qmax = (1 << (bits - 1)) - 1
+        self.qmin = -(1 << (bits - 1))
+        self.momentum = momentum
+        self.observer_steps = observer_steps
+        self.register_buffer("running_max", torch.zeros(1))
+        self.register_buffer("step", torch.zeros(1, dtype=torch.long))
+        self.enabled = True
+
+    def extra_repr(self) -> str:
+        return f"bits={self.bits}, observer_steps={self.observer_steps}, momentum={self.momentum}"
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.enabled:
+            return x
+        if self.training:
+            cur_max = x.detach().abs().amax().to(self.running_max.dtype)
+            if self.step.item() == 0:
+                self.running_max.copy_(cur_max.unsqueeze(0))
+            else:
+                self.running_max.mul_(self.momentum).add_(cur_max.unsqueeze(0) * (1.0 - self.momentum))
+            self.step += 1
+            # Warmup: collect stats only; passing x through unquantized lets the
+            # observer stabilize before fake-quant starts perturbing gradients.
+            if self.step.item() < self.observer_steps:
+                return x
+        max_abs = self.running_max.clamp_min(1e-8)
+        scale = (max_abs / self.qmax).to(x.dtype)
+        zp = torch.zeros_like(scale)
+        return fake_quantize(x, scale, zp, self.qmin, self.qmax)
+
+
+class QATLinear(nn.Linear):
+    """nn.Linear with fake-quant on input activation and on weight."""
+
+    def __init__(self, in_features, out_features, bias=True, *, w_bits=8, a_bits=8,
+                 a_momentum=0.99, a_observer_steps=200):
+        super().__init__(in_features, out_features, bias=bias)
+        self.weight_fq = WeightFakeQuant(bits=w_bits)
+        self.act_fq = ActFakeQuant(bits=a_bits, momentum=a_momentum, observer_steps=a_observer_steps)
+
+    @classmethod
+    def from_float(cls, linear: nn.Linear, **kw) -> "QATLinear":
+        qm = cls(linear.in_features, linear.out_features, bias=linear.bias is not None, **kw)
+        # Share existing tensors so optimizer state stays attached after swap.
+        qm.weight = linear.weight
+        if linear.bias is not None:
+            qm.bias = linear.bias
+        return qm
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_q = self.act_fq(x)
+        w_q = self.weight_fq(self.weight)
+        return F.linear(x_q, w_q, self.bias)
+
+
+DEFAULT_SKIP_PATTERNS = ("lm_head", "mlp.gate")
+
+
+def _matches_skip(full_name: str, pattern: str) -> bool:
+    """Pattern matches at a dot boundary, so 'mlp.gate' does NOT skip 'mlp.gate_proj'."""
+    return full_name == pattern or full_name.endswith("." + pattern)
+
+
+def prepare_qat(model: nn.Module, w_bits: int = 8, a_bits: int = 8,
+                skip_patterns=DEFAULT_SKIP_PATTERNS,
+                a_momentum: float = 0.99, a_observer_steps: int = 200) -> int:
+    """Swap every nn.Linear in `model` with QATLinear in place.
+
+    A Linear is skipped iff its qualified name equals a skip pattern or ends
+    with `'.' + pattern` (segment-aware, not substring). Defaults skip the LM
+    head (precision-sensitive, often tied to embeddings) and the MoE router
+    `mlp.gate` (small, routing-sensitive) without touching the dense
+    FeedForward's `mlp.gate_proj`.
+
+    Returns the number of linears replaced.
+    """
+    replaced = 0
+    for parent_name, parent in model.named_modules():
+        for child_name, child in list(parent.named_children()):
+            if not isinstance(child, nn.Linear) or isinstance(child, QATLinear):
+                continue
+            full_name = f"{parent_name}.{child_name}" if parent_name else child_name
+            if any(_matches_skip(full_name, p) for p in skip_patterns):
+                continue
+            new_mod = QATLinear.from_float(
+                child, w_bits=w_bits, a_bits=a_bits,
+                a_momentum=a_momentum, a_observer_steps=a_observer_steps,
+            )
+            # Move buffers to weight's device. dtype on buffers stays fp32 on purpose.
+            new_mod.act_fq.running_max = new_mod.act_fq.running_max.to(child.weight.device)
+            new_mod.act_fq.step = new_mod.act_fq.step.to(child.weight.device)
+            setattr(parent, child_name, new_mod)
+            replaced += 1
+    return replaced
+
+
+def set_act_quant_enabled(model: nn.Module, enabled: bool) -> None:
+    """Toggle activation fake-quant (e.g. disable for eval-on-fp comparison)."""
+    for m in model.modules():
+        if isinstance(m, ActFakeQuant):
+            m.enabled = enabled
+
+
+@torch.no_grad()
+def bake_quantized_weights(model: nn.Module) -> None:
+    """Replace each QATLinear's weight with its fake-quantized value, in place.
+
+    After this, the model can run as plain QATLinears without further weight
+    updates and the saved fp weights already reflect the int8 grid; useful for
+    final eval / export.
+    """
+    for m in model.modules():
+        if isinstance(m, QATLinear):
+            m.weight.copy_(m.weight_fq(m.weight))

--- a/scripts/analyze_profile.py
+++ b/scripts/analyze_profile.py
@@ -1,0 +1,197 @@
+"""
+Parse torch.profiler chrome trace, summarize top ops + backend detection.
+
+Usage:
+    # trace_out/ 是 train_pretrain.py --profile_out 指定的目录
+    python analyze_profile.py --trace_dir ../profile_out
+
+    # 或指定具体 trace 文件（一个 rank 一个）
+    python analyze_profile.py --trace_file ../profile_out/DEVvm54331_XXX.pt.trace.json
+"""
+import argparse
+import glob
+import gzip
+import json
+import os
+from collections import defaultdict
+
+
+# op 名 → bucket 分类规则（按前缀 / substring 匹配）
+BUCKET_RULES = [
+    ('matmul (GEMM)',        ['aten::mm', 'aten::bmm', 'aten::addmm', 'aten::linear']),
+    ('attention (SDPA/FA)',  ['flash', 'scaled_dot_product', 'sdpa', 'attention',
+                              'aten::_scaled_dot_product', 'FlashAttn', 'mem_efficient',
+                              'triton_flash', 'ampere_fp16_s16816gemm_bf16']),
+    ('elementwise (norm/act)', ['rms_norm', 'RMSNorm', 'aten::silu', 'aten::mul', 'aten::add',
+                                 'aten::div', 'aten::rsqrt', 'aten::sub', 'element_wise']),
+    ('softmax',              ['softmax', 'log_softmax', 'cross_entropy']),
+    ('rope',                 ['rope', 'rotary', 'cos', 'sin']),
+    ('embedding',            ['embedding', 'aten::embedding']),
+    ('dropout',              ['dropout']),
+    ('reduce (all-reduce/gather)', ['nccl', 'ncclAllReduce', 'ncclAllGather', 'ncclReduceScatter',
+                                     'allreduce', 'AllReduce', 'ProcessGroupNCCL']),
+    ('memory (copy/permute/view)', ['aten::to', 'aten::_to_copy', 'aten::contiguous',
+                                     'aten::permute', 'aten::view', 'aten::reshape',
+                                     'aten::transpose', 'aten::clone', 'Memcpy']),
+    ('optimizer',            ['adam', 'AdamW', 'optim', 'clip_grad']),
+]
+
+# attention backend 识别（chrome trace event name）
+SDPA_BACKENDS = {
+    'flash':      ['FlashAttn', 'flash_attn', 'triton_flash', 'ampere_fp16_s16816gemm'],
+    'mem_efficient': ['mem_efficient', 'MemEfficient', 'cutlassF'],
+    'math':       ['aten::baddbmm', 'aten::softmax'],  # naive fallback
+}
+
+
+def bucket_op(name: str) -> str:
+    ln = name.lower()
+    for bucket, patterns in BUCKET_RULES:
+        for p in patterns:
+            if p.lower() in ln:
+                return bucket
+    return 'other'
+
+
+def load_trace(path):
+    """支持 .json 和 .json.gz。"""
+    opener = gzip.open if path.endswith('.gz') else open
+    with opener(path, 'rt') as f:
+        data = json.load(f)
+    return data.get('traceEvents', data)
+
+
+def analyze(events):
+    # 只统计 CUDA kernel 时间（cat == 'kernel' 或 'cuda_runtime'）
+    # 但 torch.profiler 输出的 chrome trace 里 CUDA op 是 name+dur 的 complete event (ph=='X')
+    stats = defaultdict(lambda: {'time_us': 0, 'count': 0})
+    total_cuda_us = 0
+    sdpa_backend_hits = defaultdict(int)
+
+    for e in events:
+        if e.get('ph') != 'X':
+            continue
+        cat = e.get('cat', '')
+        name = e.get('name', '')
+        dur = e.get('dur', 0)
+        # 只关心 GPU kernel + collective + cudaLaunch，跳过 python-level
+        if cat not in ('kernel', 'cuda_runtime', 'user_annotation', 'gpu_memcpy', 'gpu_memset', 'cpu_op'):
+            continue
+        if cat == 'cpu_op' and 'ncclAllReduce' not in name and 'sync' not in name.lower():
+            # CPU op 大部分是 dispatch overhead，除了 NCCL / sync 都跳
+            continue
+        stats[name]['time_us'] += dur
+        stats[name]['count'] += 1
+        if cat in ('kernel', 'gpu_memcpy', 'gpu_memset'):
+            total_cuda_us += dur
+
+        # 探测 attention backend
+        for backend, patterns in SDPA_BACKENDS.items():
+            for p in patterns:
+                if p in name:
+                    sdpa_backend_hits[backend] += dur
+
+    return stats, total_cuda_us, sdpa_backend_hits
+
+
+def format_us(us):
+    if us > 1e6: return f'{us/1e6:.2f} s'
+    if us > 1e3: return f'{us/1e3:.2f} ms'
+    return f'{us:.0f} us'
+
+
+def report(stats, total_cuda_us, sdpa_backend_hits, top_n=25):
+    print(f'\n{"=" * 80}')
+    print(f'  Total CUDA time in trace: {format_us(total_cuda_us)}')
+    print(f'{"=" * 80}')
+
+    # bucket 汇总
+    bucket_time = defaultdict(int)
+    bucket_count = defaultdict(int)
+    for name, s in stats.items():
+        b = bucket_op(name)
+        bucket_time[b] += s['time_us']
+        bucket_count[b] += s['count']
+
+    print(f'\n  Time by bucket (% of total CUDA):')
+    print(f'  {"bucket":40s} {"time":>12s} {"% total":>8s} {"# calls":>8s}')
+    for bucket, t in sorted(bucket_time.items(), key=lambda kv: -kv[1]):
+        pct = t / max(total_cuda_us, 1) * 100
+        print(f'  {bucket:40s} {format_us(t):>12s} {pct:>7.1f}% {bucket_count[bucket]:>8d}')
+
+    # attention backend 探测
+    print(f'\n  Attention backend detection:')
+    if sdpa_backend_hits:
+        winner = max(sdpa_backend_hits.items(), key=lambda kv: kv[1])
+        for backend, t in sorted(sdpa_backend_hits.items(), key=lambda kv: -kv[1]):
+            marker = ' ← DOMINANT' if backend == winner[0] else ''
+            print(f'    {backend:20s}: {format_us(t):>12s}{marker}')
+        if winner[0] != 'flash':
+            print(f'  ⚠️  Not using FlashAttention. Expected FA2 on A100 for hidden 128/heads 16 → suboptimal.')
+            print(f'     Fix: 训练里用 `torch.nn.attention.sdpa_kernel(SDPBackend.FLASH_ATTENTION)` context')
+    else:
+        print(f'    (未识别到 attention kernel——可能 kernel 名 encoded 或未走 SDPA)')
+
+    # top ops 明细
+    print(f'\n  Top {top_n} CUDA ops:')
+    print(f'  {"rank":>4s} {"time":>12s} {"% total":>8s} {"# calls":>8s}  {"name":s}')
+    sorted_ops = sorted(stats.items(), key=lambda kv: -kv[1]['time_us'])
+    for i, (name, s) in enumerate(sorted_ops[:top_n], 1):
+        pct = s['time_us'] / max(total_cuda_us, 1) * 100
+        # 截断长 kernel 名
+        display_name = name if len(name) < 80 else name[:77] + '...'
+        print(f'  {i:>4d} {format_us(s["time_us"]):>12s} {pct:>7.1f}% {s["count"]:>8d}  {display_name}')
+
+    # 分类建议
+    print(f'\n{"=" * 80}')
+    print(f'  优化提示（按 bucket 比例）:')
+    print(f'{"=" * 80}')
+    total = total_cuda_us
+    reduce_pct = bucket_time.get('reduce (all-reduce/gather)', 0) / max(total, 1) * 100
+    if reduce_pct > 15:
+        print(f'  ⚠️  reduce/collective 占 {reduce_pct:.1f}%（>15% 算高）→ 考虑：')
+        print(f'      - `no_sync()` 包 gradient accumulation 减少 3× 冗余 all-reduce')
+        print(f'      - FSDP: 用 ZeRO-2/3 拆 optimizer state 减少每次 sync 数据量')
+    elem_pct = bucket_time.get('elementwise (norm/act)', 0) / max(total, 1) * 100
+    if elem_pct > 15:
+        print(f'  ⚠️  elementwise 占 {elem_pct:.1f}%（>15% 算高）→ memory bandwidth bound')
+        print(f'      - Fused RMSNorm + SiLU + Add kernel（apex 或 triton）省 50%+')
+    mem_pct = bucket_time.get('memory (copy/permute/view)', 0) / max(total, 1) * 100
+    if mem_pct > 8:
+        print(f'  ⚠️  memory movement 占 {mem_pct:.1f}%（>8% 算高）→ 布局问题')
+        print(f'      - 检查 permute/transpose/contiguous 频次，可能重复布局转换')
+    attn_pct = bucket_time.get('attention (SDPA/FA)', 0) / max(total, 1) * 100
+    matmul_pct = bucket_time.get('matmul (GEMM)', 0) / max(total, 1) * 100
+    print(f'\n  Matmul + Attention (核心 compute): {matmul_pct + attn_pct:.1f}%')
+    print(f'  如果这个数 <50%，多数时间在做非核心 op → 有巨大优化空间')
+    print(f'  Llama 3 训练里这个数一般 60-75%')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--trace_file', type=str, default=None)
+    parser.add_argument('--trace_dir', type=str, default='../profile_out')
+    parser.add_argument('--top_n', type=int, default=25)
+    args = parser.parse_args()
+
+    if args.trace_file:
+        files = [args.trace_file]
+    else:
+        # torch.profiler 每 rank 一个文件；分析 rank 0 即可
+        files = sorted(glob.glob(os.path.join(args.trace_dir, '*.pt.trace.json*')))
+        if not files:
+            print(f'no trace file found in {args.trace_dir}')
+            return
+        # 只取第一个（一般 rank 0）
+        files = files[:1]
+
+    for f in files:
+        print(f'\n[loading] {f} ({os.path.getsize(f)/1e6:.1f} MB)')
+        events = load_trace(f)
+        print(f'[loaded] {len(events):,} events')
+        stats, total, sdpa_hits = analyze(events)
+        report(stats, total, sdpa_hits, top_n=args.top_n)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_parallel.sh
+++ b/scripts/compare_parallel.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# 分布式并行策略对比 smoke tests
+#
+# 目的：跑 5-6 种并行策略各 100 步，收集 MFU / tokens/s / 每卡显存 → Design Doc #2 素材表
+#
+# ⚠️ 前置：**必须先 kill 当前 1B 训练**（4 卡全被占）：
+#   pkill -9 -f 'train_pretrain|torchrun|multiproc'
+#   然后确认 nvidia-smi 显存 <100 MB/卡
+#
+# 用法：
+#   scripts/compare_parallel.sh              # 跑所有对比
+#   scripts/compare_parallel.sh ddp           # 只跑 DDP
+#   scripts/compare_parallel.sh fsdp_full     # 只跑 FSDP full shard
+#   scripts/compare_parallel.sh tp            # 只跑 TP=2×DP=2
+#
+# 输出：/tmp/parallel_compare/*.log；最后自动 summarize 到 stdout
+set -e
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+OUT_DIR=/tmp/parallel_compare
+mkdir -p "$OUT_DIR"
+
+# 公共配置（保持对比公平：同 bs / seq / accum / model）
+COMMON_ARGS=(
+    --hidden_size 2048
+    --num_hidden_layers 20
+    --max_seq_len 1024
+    --batch_size 16
+    --accumulation_steps 1
+    --learning_rate 3e-4
+    --warmup_steps 50
+    --dtype bfloat16
+    --num_workers 4
+    --use_compile 1
+    --data_path "$REPO/dataset/skypile_test.jsonl"
+    --eval_interval 0
+    --save_interval 100000
+    --log_interval 10
+    --save_weight parallel_smoke
+    --save_dir "$REPO/out"
+)
+
+run_config() {
+    local name="$1"
+    shift
+    local strategy_args=("$@")
+    local log="$OUT_DIR/$name.log"
+    echo ""
+    echo "=========================================="
+    echo "  Running: $name"
+    echo "  extra: ${strategy_args[*]}"
+    echo "=========================================="
+    cd "$REPO/trainer"
+    # timeout 3 min 强制停：100 步跑不完就当异常，不用等
+    timeout 180 torchrun --nproc_per_node=4 --standalone train_pretrain.py \
+        "${COMMON_ARGS[@]}" \
+        "${strategy_args[@]}" > "$log" 2>&1 || true
+    echo "  最后 5 条 MFU log："
+    grep -E 'MFU' "$log" 2>/dev/null | grep -v 'params_flops' | tail -5 || echo "  (no MFU logs — crashed?)"
+    # 收显存 (kill 前抓)
+    nvidia-smi --query-gpu=memory.used --format=csv,noheader | head -1 > "$OUT_DIR/${name}_gpu.csv" || true
+    ps aux | grep -E 'train_pretrain|torchrun|multiproc' | grep -v grep | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
+    sleep 5
+}
+
+CONFIG="${1:-all}"
+
+case "$CONFIG" in
+    all)
+        run_config "ddp"          --parallel_strategy ddp
+        run_config "fsdp_no"      --parallel_strategy fsdp_no
+        run_config "fsdp_grad_op" --parallel_strategy fsdp_grad_op
+        run_config "fsdp_full"    --parallel_strategy fsdp_full
+        run_config "tp2_dp2"      --parallel_strategy tp --tp_size 2
+        run_config "tp4_dp1"      --parallel_strategy tp --tp_size 4
+        ;;
+    ddp|fsdp_no|fsdp_grad_op|fsdp_full)
+        run_config "$CONFIG" --parallel_strategy "$CONFIG"
+        ;;
+    tp|tp2)
+        run_config "tp2_dp2" --parallel_strategy tp --tp_size 2
+        ;;
+    tp4)
+        run_config "tp4_dp1" --parallel_strategy tp --tp_size 4
+        ;;
+    *)
+        echo "Unknown config: $CONFIG"
+        echo "Valid: all | ddp | fsdp_no | fsdp_grad_op | fsdp_full | tp | tp4"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "=========================================="
+echo "  Summary (稳态 = 各 log 最后一条 MFU)"
+echo "=========================================="
+printf "%-16s %-10s %-10s %-12s\n" "strategy" "it/s" "MFU%" "mem/card"
+printf "%-16s %-10s %-10s %-12s\n" "--------" "----" "----" "--------"
+
+for log in "$OUT_DIR"/*.log; do
+    [ -f "$log" ] || continue
+    name=$(basename "$log" .log)
+    line=$(grep -E 'MFU' "$log" 2>/dev/null | grep -v 'params_flops' | tail -1)
+    mem_file="$OUT_DIR/${name}_gpu.csv"
+    mem=$(cat "$mem_file" 2>/dev/null | tr -d ' ' || echo "?")
+    if [ -z "$line" ]; then
+        printf "%-16s %-10s %-10s %-12s\n" "$name" "-" "-" "crashed"
+    else
+        its=$(echo "$line" | grep -oE 'it/s: [0-9.]+' | awk '{print $2}')
+        mfu=$(echo "$line" | grep -oE 'MFU: [0-9.]+' | awk '{print $2}')
+        printf "%-16s %-10s %-10s %-12s\n" "$name" "$its" "$mfu%" "$mem"
+    fi
+done
+
+echo ""
+echo "详细 log: $OUT_DIR/*.log"
+echo "profile 单个: scripts/compare_parallel.sh $CONFIG 时加 --profile_steps 20 到 COMMON_ARGS"

--- a/scripts/download_skypile.py
+++ b/scripts/download_skypile.py
@@ -1,0 +1,163 @@
+"""
+Streaming 下载 SkyPile-150B 子采样，转成 minimind PretrainDataset 兼容格式（{"text": ...}）。
+
+特性：
+- Streaming：不全下，边读边写，磁盘只占目标量
+- Token 计数：精确控制下载量（按 budget 而非样本数停）
+- 断点续传：进程被杀也能从最后写到的行接着下
+- 进度日志：每 N 个样本打印进度
+- 简易过滤：太短 / 重复字符多的样本跳过
+
+Usage:
+    # 默认下 25B tokens（1B 模型 Chinchilla 最优）
+    python download_skypile.py
+
+    # 改下载量
+    python download_skypile.py --target_tokens 10_000_000_000
+
+    # 改输出路径
+    python download_skypile.py --output ../dataset/skypile_25b.jsonl
+
+需要 fwdproxy（HuggingFace 在 allowlist 但 OD 无直接 DNS）：
+    export https_proxy=http://fwdproxy:8080
+    export http_proxy=http://fwdproxy:8080
+"""
+import os
+import sys
+
+__package__ = "scripts"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
+import json
+import time
+import warnings
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+warnings.filterwarnings('ignore')
+
+
+def count_tokens_fast(text: str) -> int:
+    """快速估算 token 数：中文按字符 ≈ token，英文按词 × 1.3。
+    用于在线计数（精确 tokenize 太慢）。"""
+    n_chars = len(text)
+    # 中文 token ≈ 1 char；英文 1 token ≈ 4 char
+    # 简单估算：取个折中
+    return int(n_chars / 1.8)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stream-download SkyPile-150B subset")
+    parser.add_argument('--repo', default='Skywork/SkyPile-150B', type=str)
+    parser.add_argument('--split', default='train', type=str)
+    parser.add_argument('--output', default='../dataset/skypile_25b.jsonl', type=str)
+    parser.add_argument('--target_tokens', type=int, default=25_000_000_000,
+                        help='目标 token 数（estimate），到达后停止')
+    parser.add_argument('--min_length', type=int, default=200,
+                        help='样本最小字符数，太短跳过')
+    parser.add_argument('--log_every', type=int, default=5000)
+    parser.add_argument('--tokenizer_path', type=str, default='../model',
+                        help='用 minimind tokenizer 精确计算 token 数（每 N 个样本核对一次）')
+    parser.add_argument('--exact_count_every', type=int, default=50000,
+                        help='每 N 个样本精确 tokenize 一次校准估算误差')
+    args = parser.parse_args()
+
+    output_path = os.path.abspath(args.output)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # 断点续传：count 已有文件的行数
+    n_written, est_tokens_written = 0, 0
+    if os.path.exists(output_path):
+        print(f'[resume] found existing {output_path}, counting...')
+        with open(output_path) as f:
+            for line in f:
+                n_written += 1
+                try:
+                    est_tokens_written += count_tokens_fast(json.loads(line)['text'])
+                except Exception:
+                    pass
+        print(f'[resume] {n_written:,} samples already written, ~{est_tokens_written/1e9:.2f}B tokens')
+        if est_tokens_written >= args.target_tokens:
+            print('[resume] target already reached, exit')
+            return
+
+    # 校准 tokenizer（可选；下载完后跑 eval_perplexity 时会用到）
+    tokenizer = None
+    if args.tokenizer_path:
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path)
+            print(f'[tokenizer] loaded for calibration: vocab={tokenizer.vocab_size}')
+        except Exception as e:
+            print(f'[tokenizer] failed to load ({e}), will skip calibration')
+
+    print(f'[start] streaming {args.repo} split={args.split} → {output_path}')
+    print(f'[target] {args.target_tokens/1e9:.1f}B tokens (estimated)')
+
+    ds = load_dataset(args.repo, split=args.split, streaming=True)
+
+    skipped_short = 0
+    n_seen = 0
+    t0 = time.time()
+    calibration_ratio = 1.0  # actual_tokens / estimated_tokens，每次校准更新
+
+    with open(output_path, 'a') as fout:
+        for sample in ds:
+            n_seen += 1
+            # 跳过已写过的（断点续传）
+            if n_seen <= n_written:
+                continue
+
+            text = sample.get('text', '')
+            if len(text) < args.min_length:
+                skipped_short += 1
+                continue
+
+            est_tok = count_tokens_fast(text)
+            actual_est = int(est_tok * calibration_ratio)
+
+            # 写入 minimind 格式
+            fout.write(json.dumps({'text': text}, ensure_ascii=False) + '\n')
+            n_written += 1
+            est_tokens_written += actual_est
+
+            # 进度日志
+            if n_written % args.log_every == 0:
+                elapsed = time.time() - t0
+                rate = (n_written / elapsed) if elapsed > 0 else 0
+                progress = est_tokens_written / args.target_tokens * 100
+                eta_h = (args.target_tokens - est_tokens_written) / max(est_tokens_written / elapsed, 1) / 3600
+                print(f'[{n_written:>9,} samples] {est_tokens_written/1e9:>5.2f}B tok '
+                      f'({progress:>5.1f}%) | {rate:.0f} samples/s | ETA {eta_h:.1f}h | '
+                      f'skipped_short={skipped_short:,}')
+                fout.flush()
+
+            # 周期性精确 tokenize 几条校准估算
+            if tokenizer and n_written % args.exact_count_every == 0:
+                actual = sum(len(tokenizer(t, add_special_tokens=False).input_ids)
+                             for t in [text])
+                estimate = est_tok
+                if estimate > 0:
+                    new_ratio = actual / estimate
+                    calibration_ratio = 0.9 * calibration_ratio + 0.1 * new_ratio
+                    print(f'[calibration] est_ratio updated → {calibration_ratio:.3f} '
+                          f'(this sample: est={estimate}, actual={actual})')
+
+            if est_tokens_written >= args.target_tokens:
+                print(f'\n[done] target reached: {est_tokens_written/1e9:.2f}B est tokens')
+                break
+
+    elapsed = time.time() - t0
+    print(f'\n{"=" * 60}')
+    print(f'Total: {n_written:,} samples, ~{est_tokens_written/1e9:.2f}B est tokens')
+    print(f'Elapsed: {elapsed/60:.1f} min ({elapsed/3600:.1f}h)')
+    print(f'Skipped (too short): {skipped_short:,}')
+    print(f'Output: {output_path} ({os.path.getsize(output_path)/1e9:.2f} GB)')
+    print(f'{"=" * 60}')
+    if tokenizer:
+        print(f'⚠️  估算 token 数有 ~{abs(1-calibration_ratio)*100:.1f}% 误差。')
+        print(f'   精确数：跑 eval_perplexity.py 时会有 actual count。')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_completion.py
+++ b/scripts/eval_completion.py
@@ -1,0 +1,147 @@
+"""
+Qualitative eval of a MiniMind pretrain (or post-pretrain) checkpoint by sampling
+text continuations from a fixed prompt set spanning multiple domains.
+
+For pretrain (base) models — does NOT use chat template. Use eval_llm.py for SFT models.
+
+Usage:
+    # Default: 64M pretrain ckpt
+    python eval_completion.py
+
+    # 1B ckpt
+    python eval_completion.py --hidden_size 2048 --num_hidden_layers 20 --weight pretrain
+
+    # Custom prompt
+    python eval_completion.py --prompt "今天天气不错，我打算"
+
+    # Save outputs to markdown for design doc
+    python eval_completion.py --output_md eval_results.md
+
+What to look for:
+    ✓ Grammatically coherent Chinese, no repetition loops
+    ✓ Stays roughly on topic of the prefix
+    ✓ Variety across runs (different temperature should give different outputs)
+    ✗ Repetitive: "的的的的" / 同一句重复 → 训练或解码有问题
+    ✗ 全部生成都一模一样 → 模型坍缩 / temperature 太低
+    ✗ 乱码 / 非中文片段（如果是纯中文 prefix）→ tokenizer 问题
+"""
+import os
+import sys
+
+__package__ = "scripts"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
+import warnings
+import time
+import torch
+from transformers import AutoTokenizer, TextStreamer
+from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
+
+warnings.filterwarnings('ignore')
+
+
+DEFAULT_PROMPTS = [
+    ("叙事",     "在很久很久以前，有一个小村庄，"),
+    ("日常",     "今天天气不错，我打算"),
+    ("技术",     "Python 是一种编程语言，它的特点是"),
+    ("事实",     "中华人民共和国成立于"),
+    ("代码",     "def fibonacci(n):\n    if n < 2:"),
+    ("科学",     "牛顿第一定律说的是"),
+    ("文学",     "李白是唐代著名的"),
+    ("数学",     "二的十次方等于"),
+    ("常识",     "水的沸点在标准大气压下是"),
+    ("地理",     "中国的首都是"),
+]
+
+
+def load_model(args):
+    cfg = MiniMindConfig(
+        hidden_size=args.hidden_size,
+        num_hidden_layers=args.num_hidden_layers,
+        use_moe=bool(args.use_moe),
+    )
+    model = MiniMindForCausalLM(cfg)
+    moe_suffix = '_moe' if args.use_moe else ''
+    ckp = f'{args.save_dir}/{args.weight}_{args.hidden_size}{moe_suffix}.pth'
+    state_dict = torch.load(ckp, map_location='cpu', weights_only=True)
+    model.load_state_dict(state_dict, strict=False)
+    model = model.half().eval().to(args.device)
+    return model, cfg
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(description="MiniMind Pretrain Completion Eval")
+    parser.add_argument('--hidden_size', type=int, default=768)
+    parser.add_argument('--num_hidden_layers', type=int, default=8)
+    parser.add_argument('--use_moe', type=int, default=0, choices=[0, 1])
+    parser.add_argument('--save_dir', type=str, default='../out')
+    parser.add_argument('--weight', type=str, default='pretrain')
+    parser.add_argument('--tokenizer_path', type=str, default='../model')
+    parser.add_argument('--prompt', type=str, default=None,
+                        help='单条自定义 prompt；不指定则跑 DEFAULT_PROMPTS 全集')
+    parser.add_argument('--max_new_tokens', type=int, default=80)
+    parser.add_argument('--temperature', type=float, default=0.7)
+    parser.add_argument('--top_p', type=float, default=0.9)
+    parser.add_argument('--top_k', type=int, default=50)
+    parser.add_argument('--repetition_penalty', type=float, default=1.1)
+    parser.add_argument('--num_samples_per_prompt', type=int, default=1,
+                        help='每个 prompt 采样几次（验证多样性）')
+    parser.add_argument('--output_md', type=str, default=None,
+                        help='输出 markdown 报告路径（可选）')
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
+    parser.add_argument('--seed', type=int, default=42)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+
+    print(f'[load] ckpt={args.save_dir}/{args.weight}_{args.hidden_size}.pth')
+    model, cfg = load_model(args)
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path)
+
+    prompts = [('custom', args.prompt)] if args.prompt else DEFAULT_PROMPTS
+
+    md_lines = []
+    md_lines.append(f'# Completion Eval: `{args.weight}_{args.hidden_size}.pth`')
+    md_lines.append(f'temperature={args.temperature}, top_p={args.top_p}, top_k={args.top_k}, '
+                    f'rep_penalty={args.repetition_penalty}, max_new={args.max_new_tokens}\n')
+
+    for label, prompt in prompts:
+        print(f'\n{"=" * 60}')
+        print(f'[{label}] Prompt: {prompt!r}')
+        md_lines.append(f'## [{label}] `{prompt}`\n')
+        for sample_i in range(args.num_samples_per_prompt):
+            print(f'\n--- Sample {sample_i + 1} ---')
+            # 必须加 BOS：训练时所有样本以 [BOS] 开头，eval 时不加 BOS 模型会产生 degenerate
+            # 输出（"的的的"/"是是是" 重复），因为它从没见过"无 BOS 开头"的序列
+            body = tokenizer(prompt, add_special_tokens=False).input_ids
+            ids = torch.tensor([[tokenizer.bos_token_id] + body], device=args.device)
+            t0 = time.time()
+            output_ids = model.generate(
+                ids,
+                max_new_tokens=args.max_new_tokens,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                top_k=args.top_k,
+                repetition_penalty=args.repetition_penalty,
+                do_sample=True,
+                eos_token_id=tokenizer.eos_token_id,
+            )
+            elapsed = time.time() - t0
+            text = tokenizer.decode(output_ids[0].tolist(), skip_special_tokens=True)
+            continuation = text[len(prompt):]
+            print(continuation)
+            new_tokens = output_ids.shape[1] - ids.shape[1]
+            print(f'  [{new_tokens} new tokens in {elapsed:.2f}s = {new_tokens/elapsed:.1f} tok/s]')
+            md_lines.append(f'**Sample {sample_i + 1}**: {continuation.strip()}\n')
+        md_lines.append('')
+
+    if args.output_md:
+        with open(args.output_md, 'w') as f:
+            f.write('\n'.join(md_lines))
+        print(f'\n[saved] {args.output_md}')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_perplexity.py
+++ b/scripts/eval_perplexity.py
@@ -38,6 +38,11 @@ from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
 warnings.filterwarnings('ignore')
 
 
+def _is_qat_state_dict(sd):
+    """QAT ckpt 会带 act_fq.running_max / act_fq.step buffer——用它判定要不要先 wrap。"""
+    return any('act_fq.running_max' in k for k in sd.keys())
+
+
 def load_model(args):
     cfg = MiniMindConfig(
         hidden_size=args.hidden_size,
@@ -48,10 +53,71 @@ def load_model(args):
     moe_suffix = '_moe' if args.use_moe else ''
     ckp = f'{args.save_dir}/{args.weight}_{args.hidden_size}{moe_suffix}.pth'
     state_dict = torch.load(ckp, map_location='cpu', weights_only=True)
-    # strict=False — tied embeddings have duplicate keys; load handles via shared storage
-    model.load_state_dict(state_dict, strict=False)
-    model = model.half().eval().to(args.device)
-    return model, cfg
+
+    is_qat_ckpt = _is_qat_state_dict(state_dict)
+    apply_qat = bool(args.apply_qat) or is_qat_ckpt
+
+    if apply_qat:
+        from model.quant import prepare_qat, bake_quantized_weights
+        skip_patterns = tuple(s.strip() for s in args.quant_skip.split(',') if s.strip())
+        if is_qat_ckpt:
+            # QAT ckpt 已含 buffer——先 wrap 出对应 module，再整体 load
+            replaced = prepare_qat(model, w_bits=args.w_bits, a_bits=args.a_bits,
+                                   skip_patterns=skip_patterns)
+            model.load_state_dict(state_dict, strict=False)
+            print(f'[QAT] loaded QAT ckpt, wrapped {replaced} Linear modules')
+        else:
+            # fp ckpt——先 load 权重，再 wrap（QATLinear.from_float 保留原 weight tensor）
+            model.load_state_dict(state_dict, strict=False)
+            replaced = prepare_qat(model, w_bits=args.w_bits, a_bits=args.a_bits,
+                                   skip_patterns=skip_patterns)
+            print(f'[QAT] wrapped fp ckpt with {replaced} QATLinear (observer un-calibrated)')
+
+        model = model.half().to(args.device)
+
+        if not is_qat_ckpt and args.qat_calibrate > 0:
+            # 对未训练过的 QAT 模型：observer running_max 全 0，直接 eval 会 scale ~= 0 全饱和
+            # 跑一段 train() 模式的 forward 让 EMA 收敛，再切 eval
+            _calibrate_observer(model, args)
+
+        if args.qat_bake:
+            print('[QAT] baking fake-quantized weights in-place (simulates deployed int8)')
+            bake_quantized_weights(model)
+    else:
+        # strict=False — tied embeddings have duplicate keys; load handles via shared storage
+        model.load_state_dict(state_dict, strict=False)
+        model = model.half().to(args.device)
+
+    return model.eval(), cfg
+
+
+@torch.no_grad()
+def _calibrate_observer(model, args):
+    """在 train() 模式下跑 N 个 forward 把 ActFakeQuant.running_max EMA 跑起来。
+
+    ActFakeQuant.forward 里 self.training 分支才会更新 EMA + 记 step；observer_steps
+    warmup 期内也不做 fake-quant，只统计。这里跑够 observer_steps 步保证之后 eval
+    切进真正 fake-quant 分支。
+    """
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path)
+    bos_id, eos_id = tokenizer.bos_token_id, tokenizer.eos_token_id
+    model.train()
+    fed = 0
+    for text in iter_holdout(args):
+        if not text or len(text) < 10:
+            continue
+        body = tokenizer(text, max_length=args.max_seq_len - 2,
+                         truncation=True, add_special_tokens=False).input_ids
+        tokens = [bos_id] + body + [eos_id]
+        if len(tokens) < 2:
+            continue
+        ids = torch.tensor([tokens], device=args.device)
+        model(input_ids=ids)
+        fed += 1
+        if fed >= args.qat_calibrate:
+            break
+    model.eval()
+    print(f'[QAT] calibration done ({fed} forwards; observer_steps warmup = {args.qat_calibrate})')
 
 
 def iter_holdout(args):
@@ -91,6 +157,18 @@ def main():
     parser.add_argument('--max_samples', type=int, default=500)
     parser.add_argument('--max_seq_len', type=int, default=512)
     parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
+
+    # ---- QAT eval options ----
+    parser.add_argument('--apply_qat', type=int, default=0, choices=[0, 1],
+                        help='对 fp ckpt 也用 QATLinear 包一层，测纯量化噪声；QAT ckpt 会自动识别')
+    parser.add_argument('--w_bits', type=int, default=8)
+    parser.add_argument('--a_bits', type=int, default=8)
+    parser.add_argument('--qat_calibrate', type=int, default=200,
+                        help='fp ckpt + apply_qat 时的 observer 预热步数；QAT ckpt 时忽略')
+    parser.add_argument('--qat_bake', type=int, default=0, choices=[0, 1],
+                        help='把 fake-quantized 权重 in-place 写回 weight（模拟真实 int8 部署）')
+    parser.add_argument('--quant_skip', type=str, default='lm_head,mlp.gate',
+                        help='要跳过量化的 Linear 名（逗号分隔），需和训练一致')
     args = parser.parse_args()
 
     print(f'[load] ckpt={args.save_dir}/{args.weight}_{args.hidden_size}.pth')

--- a/scripts/eval_perplexity.py
+++ b/scripts/eval_perplexity.py
@@ -1,0 +1,147 @@
+"""
+Compute perplexity of a MiniMind checkpoint on a holdout text dataset.
+
+Usage:
+    # Default: 64M pretrain ckpt, hash-sampled 1% of pretrain_t2t.jsonl
+    python eval_perplexity.py
+
+    # 1B ckpt with explicit holdout
+    python eval_perplexity.py --hidden_size 2048 --num_hidden_layers 20 \\
+        --weight pretrain --holdout_file ../dataset/holdout.jsonl
+
+    # Compare two ckpts (e.g. before/after QAT)
+    python eval_perplexity.py --weight pretrain
+    python eval_perplexity.py --weight qat
+
+Reference PPL ranges (rough):
+    64M from-scratch on Chinese pretrain holdout:  8-15
+    200M:  6-10
+    1B:    5-8
+    Anything > 30 → training is broken (data leak, lr too high, etc.)
+    Anything < 5 → suspect data leak (test set seen during training)
+"""
+import os
+import sys
+
+__package__ = "scripts"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
+import json
+import math
+import warnings
+import time
+import torch
+from transformers import AutoTokenizer
+from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
+
+warnings.filterwarnings('ignore')
+
+
+def load_model(args):
+    cfg = MiniMindConfig(
+        hidden_size=args.hidden_size,
+        num_hidden_layers=args.num_hidden_layers,
+        use_moe=bool(args.use_moe),
+    )
+    model = MiniMindForCausalLM(cfg)
+    moe_suffix = '_moe' if args.use_moe else ''
+    ckp = f'{args.save_dir}/{args.weight}_{args.hidden_size}{moe_suffix}.pth'
+    state_dict = torch.load(ckp, map_location='cpu', weights_only=True)
+    # strict=False — tied embeddings have duplicate keys; load handles via shared storage
+    model.load_state_dict(state_dict, strict=False)
+    model = model.half().eval().to(args.device)
+    return model, cfg
+
+
+def iter_holdout(args):
+    """Yield text strings from holdout. Either a separate file or hash-sampled from pretrain."""
+    if args.holdout_file:
+        with open(args.holdout_file) as f:
+            for line in f:
+                d = json.loads(line)
+                yield d.get('text') or d.get('content') or ''
+        return
+    # Hash-based holdout: take 1/sampling_mod of training file (deterministic, repeatable)
+    # NOTE: only meaningful as proxy — model HAS seen these during training.
+    # True holdout requires reserving samples BEFORE training (Week 1 trainer fix).
+    with open(args.train_file) as f:
+        for line in f:
+            if hash(line) % args.sampling_mod == 0:
+                d = json.loads(line)
+                yield d.get('text') or d.get('content') or ''
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(description="MiniMind Perplexity Eval")
+    parser.add_argument('--hidden_size', type=int, default=768)
+    parser.add_argument('--num_hidden_layers', type=int, default=8)
+    parser.add_argument('--use_moe', type=int, default=0, choices=[0, 1])
+    parser.add_argument('--save_dir', type=str, default='../out')
+    parser.add_argument('--weight', type=str, default='pretrain',
+                        help='ckpt 前缀，如 pretrain / full_sft / qat')
+    parser.add_argument('--tokenizer_path', type=str, default='../model')
+    parser.add_argument('--holdout_file', type=str, default=None,
+                        help='独立 holdout jsonl 文件；若为 None 则从 train_file 按 hash 抽样')
+    parser.add_argument('--train_file', type=str, default='../dataset/pretrain_t2t.jsonl',
+                        help='没 holdout 时从这里 hash 抽样作 proxy holdout')
+    parser.add_argument('--sampling_mod', type=int, default=1000,
+                        help='hash 抽样模数：1000=取 0.1%, 100=取 1%')
+    parser.add_argument('--max_samples', type=int, default=500)
+    parser.add_argument('--max_seq_len', type=int, default=512)
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
+    args = parser.parse_args()
+
+    print(f'[load] ckpt={args.save_dir}/{args.weight}_{args.hidden_size}.pth')
+    model, cfg = load_model(args)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path)
+    pad_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
+
+    total_loss, total_tokens, n_samples = 0.0, 0, 0
+    t0 = time.time()
+    # ⚠️ 必须加 BOS/EOS：minimind PretrainDataset 训练时格式是 [BOS] + tokens + [EOS] + pad。
+    # eval 时不加 BOS，第一个 token 的 loss 会异常高（模型从来没见过"无 BOS 开头"），
+    # 整体 PPL 会虚高 ~4x（实测从 4.7 → 20.2）。
+    bos_id = tokenizer.bos_token_id
+    eos_id = tokenizer.eos_token_id
+    for text in iter_holdout(args):
+        if not text or len(text) < 10:
+            continue
+        body = tokenizer(text, max_length=args.max_seq_len - 2,
+                         truncation=True, add_special_tokens=False).input_ids
+        tokens = [bos_id] + body + [eos_id]
+        if len(tokens) < 2:
+            continue
+        ids = torch.tensor([tokens], device=args.device)
+        labels = ids.clone()
+        labels[labels == pad_id] = -100
+        out = model(input_ids=ids, labels=labels)
+        n_tokens = (labels != -100).sum().item() - 1  # 减 1：last token 不算 loss
+        if n_tokens <= 0:
+            continue
+        total_loss += out.loss.item() * n_tokens
+        total_tokens += n_tokens
+        n_samples += 1
+        if n_samples >= args.max_samples:
+            break
+
+    avg_loss = total_loss / max(total_tokens, 1)
+    ppl = math.exp(avg_loss)
+    elapsed = time.time() - t0
+    print(f'\n{"=" * 60}')
+    print(f'Samples evaluated: {n_samples}')
+    print(f'Total tokens:      {total_tokens:,}')
+    print(f'Avg loss:          {avg_loss:.4f}')
+    print(f'Perplexity (PPL):  {ppl:.2f}')
+    print(f'Elapsed:           {elapsed:.1f}s ({total_tokens/elapsed:.0f} tokens/s)')
+    print(f'{"=" * 60}')
+
+    if args.holdout_file is None:
+        print(f'⚠️  Used hash-sampled "holdout" from train_file (model HAS seen these).')
+        print(f'   For real eval, reserve a holdout BEFORE training.')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/launch_1b_pretrain.sh
+++ b/scripts/launch_1b_pretrain.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# 1B pretrain launcher — 4 卡 DDP，SkyPile stage 1（真 raw web pretrain）
+#
+# Config 基于 plan L84 + dry-run 学到的教训：
+#   - hidden=2048, layers=20, heads=16 (kv=4 GQA) → ~1.02B params
+#   - seq=1024 (SkyPile 长度足够)
+#   - global batch = 16 per GPU × 4 GPU × accum 4 = 256 → ~256*1024=262k tokens/step
+#   - lr 3e-4 (1B from-scratch 标准) + warmup 1000 (前 500 步发散风险 >50%)
+#   - eval 每 500 step，用 minimind pretrain 做 proxy holdout（1B 未见过）
+#   - save 每 2000 step（2GB × 264 次约 500GB 磁盘，可承受；1B 训 ~150k step 总量）
+#   - grad_checkpointing 0（1B seq=1024 在 A100 80GB 用不上，省 30% 时间）
+#
+# Stage 2 (minimind curated Q&A mid-training) 是另开 run，从 pretrain_1b ckpt 起点继续
+#
+# 用法:
+#   scripts/launch_1b_pretrain.sh                # 默认 4 卡
+#   scripts/launch_1b_pretrain.sh --nproc 2       # 覆盖为 2 卡
+#   scripts/launch_1b_pretrain.sh -- --learning_rate 5e-4  # 传给 python
+set -e
+
+# 默认参数
+NPROC=4
+# 分离 launcher 参数和 python 参数
+PY_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --nproc) NPROC="$2"; shift 2 ;;
+        --) shift; PY_ARGS+=("$@"); break ;;
+        *) PY_ARGS+=("$1"); shift ;;
+    esac
+done
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT/trainer"
+
+# 数据：SkyPile 是 stage 1 主战场
+DATA_PATH="../dataset/skypile_test.jsonl"
+# eval holdout：用 minimind pretrain 作 proxy（1B 训练时未见过）
+EVAL_DATA="../dataset/pretrain_t2t.jsonl"
+
+echo "[launch_1b_pretrain] NPROC=$NPROC data=$DATA_PATH"
+echo "[launch_1b_pretrain] extra args: ${PY_ARGS[*]}"
+
+torchrun --nproc_per_node=$NPROC --standalone train_pretrain.py \
+    --hidden_size 2048 \
+    --num_hidden_layers 20 \
+    --max_seq_len 1024 \
+    --batch_size 24 \
+    --accumulation_steps 4 \
+    --learning_rate 3e-4 \
+    --warmup_steps 1000 \
+    --grad_checkpointing 0 \
+    --dtype bfloat16 \
+    --num_workers 4 \
+    --use_compile 1 \
+    --data_path "$DATA_PATH" \
+    --eval_interval 500 \
+    --eval_data_path "$EVAL_DATA" \
+    --eval_max_batches 20 \
+    --save_interval 500 \
+    --log_interval 20 \
+    --save_weight pretrain_1b \
+    --save_dir ../out \
+    --wandb_project MiniMind-1B-Pretrain \
+    "${PY_ARGS[@]}"

--- a/scripts/measure_sqnr.py
+++ b/scripts/measure_sqnr.py
@@ -1,0 +1,292 @@
+"""
+Measure SQNR (Signal-to-Quantization-Noise Ratio) of MiniMind checkpoints.
+
+三个维度：
+1. Weight SQNR: 对每层 Linear.weight 应用 W8/W4 fake-quant，算 SQNR
+   - Pretrain vs QAT-trained: QAT 训练应把 W SQNR 推高（权重朝量化友好区漂）
+2. Activation SQNR: 用 forward hook 抓每层输入 activation, 用 running_max 量化后算 SQNR
+   - 需要真实数据（否则激活分布不代表推理时）
+3. Bit-width sweep: 对 pretrain 权重扫 W2/W4/W8/W16 看 SQNR ~ bits 曲线（应该 +6dB/bit）
+
+Usage:
+    cd scripts && python measure_sqnr.py                     # 默认：W SQNR (pretrain vs qat) + bit sweep
+    python measure_sqnr.py --act 1                           # 加上 activation SQNR (需要 GPU + 数据)
+    python measure_sqnr.py --act 1 --n_samples 32            # activation 用 N samples 校准
+"""
+import os
+import sys
+__package__ = "scripts"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
+import warnings
+import json
+import torch
+from transformers import AutoTokenizer
+from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
+from model.quant import WeightFakeQuant, prepare_qat, DEFAULT_SKIP_PATTERNS
+
+warnings.filterwarnings('ignore')
+
+
+def sqnr_db(x: torch.Tensor, x_q: torch.Tensor) -> float:
+    """SQNR = 10 log10(||x||² / ||x - x_q||²)，用 fp64 算防止 fp16 数值下溢。"""
+    x, x_q = x.double(), x_q.double()
+    signal_pow = (x ** 2).mean()
+    noise_pow = ((x - x_q) ** 2).mean().clamp_min(1e-24)
+    return (10.0 * torch.log10(signal_pow / noise_pow)).item()
+
+
+def is_quantizable_linear_key(k: str, skip_patterns=DEFAULT_SKIP_PATTERNS) -> bool:
+    """判断 state_dict 的 key 是否对应我们会量化的 Linear.weight。"""
+    if not k.endswith('.weight'):
+        return False
+    # 排除 embedding / norm / lm_head / MoE 路由（和 prepare_qat 的 skip 一致）
+    if 'embed_tokens' in k or 'lm_head' in k or 'norm' in k:
+        return False
+    parent = k[:-len('.weight')]
+    for pat in skip_patterns:
+        if parent == pat or parent.endswith('.' + pat):
+            return False
+    return True
+
+
+def measure_weight_sqnr(pretrain_sd, qat_sd, bits=8):
+    """对每层 Linear.weight 算 W SQNR，返回 dict {layer_name: (sqnr_pretrain, sqnr_qat, delta)}。"""
+    wfq = WeightFakeQuant(bits=bits)
+    results = {}
+    for k in pretrain_sd.keys():
+        if not is_quantizable_linear_key(k):
+            continue
+        w_pt = pretrain_sd[k].float()
+        w_pt_q = wfq(w_pt)
+        sqnr_pt = sqnr_db(w_pt, w_pt_q)
+        rec = {'pretrain': sqnr_pt}
+        if k in qat_sd:
+            w_q = qat_sd[k].float()
+            w_q_q = wfq(w_q)
+            sqnr_q = sqnr_db(w_q, w_q_q)
+            rec['qat'] = sqnr_q
+            rec['delta'] = sqnr_q - sqnr_pt
+        results[k] = rec
+    return results
+
+
+def measure_bit_sweep(pretrain_sd, bit_list=(2, 3, 4, 6, 8, 12)):
+    """对每层权重扫多个 bit，验证 ~6 dB/bit 规律。返回 dict {bits: mean_sqnr_across_layers}。"""
+    out = {}
+    for bits in bit_list:
+        wfq = WeightFakeQuant(bits=bits)
+        sqnrs = []
+        for k in pretrain_sd.keys():
+            if not is_quantizable_linear_key(k):
+                continue
+            w = pretrain_sd[k].float()
+            sqnrs.append(sqnr_db(w, wfq(w)))
+        out[bits] = sum(sqnrs) / len(sqnrs)
+    return out
+
+
+@torch.no_grad()
+def measure_activation_sqnr(cfg, qat_ckpt_path, tokenizer_path, data_path, n_samples, device='cuda'):
+    """
+    跑真实数据，用 forward hook 抓每个 QATLinear 的输入激活，
+    对比 fp 激活 vs act_fq(fp激活) 的 SQNR。使用 QAT ckpt 里训好的 running_max。
+    """
+    model = MiniMindForCausalLM(cfg)
+    prepare_qat(model, w_bits=8, a_bits=8)
+    sd = torch.load(qat_ckpt_path, map_location='cpu', weights_only=True)
+    model.load_state_dict(sd, strict=False)
+    model = model.half().eval().to(device)
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+    bos_id, eos_id = tokenizer.bos_token_id, tokenizer.eos_token_id
+
+    # 收集每个 QATLinear 的激活 SQNR（累积 sum + count 便于跨样本求平均）
+    from model.quant import QATLinear
+    stats = {}  # name -> {sum_sig_pow, sum_noise_pow, count}
+    hooks = []
+
+    def make_hook(name, act_fq):
+        def hook(mod, inp, out):
+            x = inp[0].detach()
+            x_q = act_fq(x.clone())  # 现用 QAT 训好的 running_max 量化
+            xd, xqd = x.double(), x_q.double()
+            s = (xd ** 2).sum().item()
+            n = ((xd - xqd) ** 2).sum().item()
+            if name not in stats:
+                stats[name] = {'sig': 0.0, 'noise': 0.0, 'nel': 0}
+            stats[name]['sig'] += s
+            stats[name]['noise'] += n
+            stats[name]['nel'] += x.numel()
+        return hook
+
+    for name, m in model.named_modules():
+        if isinstance(m, QATLinear):
+            hooks.append(m.register_forward_hook(make_hook(name, m.act_fq)))
+
+    # 走 N 条 pretrain 数据
+    fed = 0
+    with open(data_path) as f:
+        for line in f:
+            d = json.loads(line)
+            text = d.get('text') or d.get('content') or ''
+            if not text or len(text) < 10:
+                continue
+            body = tokenizer(text, max_length=510, truncation=True,
+                             add_special_tokens=False).input_ids
+            tokens = [bos_id] + body + [eos_id]
+            ids = torch.tensor([tokens], device=device)
+            model(input_ids=ids)
+            fed += 1
+            if fed >= n_samples:
+                break
+
+    for h in hooks:
+        h.remove()
+
+    # 转成 SQNR
+    result = {}
+    for name, s in stats.items():
+        sqnr = 10.0 * torch.log10(torch.tensor(s['sig'] / max(s['noise'], 1e-24))).item()
+        result[name] = sqnr
+    return result, fed
+
+
+def _fmt_layer_stats(results, val_key='pretrain'):
+    """紧凑打印每层 SQNR（截 layer name 到 self_attn.q_proj 之类）。"""
+    values = [(k.replace('model.layers.', 'L').replace('.weight', ''), v)
+              for k, v in results.items()]
+    return values
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--hidden_size', type=int, default=768)
+    parser.add_argument('--num_hidden_layers', type=int, default=8)
+    parser.add_argument('--use_moe', type=int, default=0)
+    parser.add_argument('--save_dir', type=str, default='../out')
+    parser.add_argument('--pretrain', type=str, default='pretrain')
+    parser.add_argument('--qat', type=str, default='qat')
+    parser.add_argument('--tokenizer_path', type=str, default='../model')
+    parser.add_argument('--data_path', type=str, default='../dataset/pretrain_t2t.jsonl')
+    parser.add_argument('--n_samples', type=int, default=32)
+    parser.add_argument('--act', type=int, default=1, choices=[0, 1],
+                        help='是否算激活 SQNR（需要 GPU + 数据）')
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
+    args = parser.parse_args()
+
+    moe_suffix = '_moe' if args.use_moe else ''
+    pt_path = f'{args.save_dir}/{args.pretrain}_{args.hidden_size}{moe_suffix}.pth'
+    qat_path = f'{args.save_dir}/{args.qat}_{args.hidden_size}{moe_suffix}.pth'
+
+    print(f'[load] pretrain: {pt_path}')
+    print(f'[load] qat:      {qat_path}')
+    pretrain_sd = torch.load(pt_path, map_location='cpu', weights_only=True)
+    qat_sd = torch.load(qat_path, map_location='cpu', weights_only=True)
+
+    # =========================================================
+    # 1. Weight SQNR: pretrain vs QAT-trained, W8
+    # =========================================================
+    print(f'\n{"=" * 70}')
+    print(f'  Weight SQNR (W8 per-out-channel symmetric)')
+    print(f'  higher = weights sit closer to int8 grid points')
+    print(f'{"=" * 70}')
+    w8_results = measure_weight_sqnr(pretrain_sd, qat_sd, bits=8)
+
+    # 分组：attn (q/k/v/o) vs ffn (gate/up/down) 分别汇总
+    def group(k):
+        if 'self_attn' in k: return 'attn'
+        if 'mlp' in k: return 'ffn'
+        return 'other'
+
+    groups = {'attn': [], 'ffn': [], 'other': []}
+    for k, r in w8_results.items():
+        groups[group(k)].append(r)
+
+    print(f"{'Group':10s} {'#layers':>8s} {'PT SQNR mean':>14s} {'QAT SQNR mean':>14s} {'Δ mean':>10s}")
+    for g, rs in groups.items():
+        if not rs: continue
+        pt_mean = sum(r['pretrain'] for r in rs) / len(rs)
+        qat_mean = sum(r.get('qat', 0) for r in rs) / len(rs)
+        delta_mean = sum(r.get('delta', 0) for r in rs) / len(rs)
+        print(f"{g:10s} {len(rs):>8d} {pt_mean:>13.2f}dB {qat_mean:>13.2f}dB {delta_mean:>+9.2f}dB")
+
+    print(f'\n  Per-layer detail (first 8 layers, all types):')
+    print(f'  {"layer":50s} {"PT dB":>8s} {"QAT dB":>8s} {"Δ":>8s}')
+    shown = 0
+    for k, r in w8_results.items():
+        if 'layers.0.' not in k: continue  # 只看第 0 层
+        short = k.replace('model.layers.0.', '').replace('.weight', '')
+        print(f'  {short:50s} {r["pretrain"]:>7.2f}  {r.get("qat", 0):>7.2f}  {r.get("delta", 0):>+7.2f}')
+        shown += 1
+
+    # 排序找最难 / 最容易量化的 3 层
+    ranked_pt = sorted(w8_results.items(), key=lambda kv: kv[1]['pretrain'])
+    print(f'\n  Hardest to quantize (lowest PT SQNR):')
+    for k, r in ranked_pt[:3]:
+        print(f'    {k:60s}  {r["pretrain"]:.2f} dB')
+    print(f'  Easiest to quantize (highest PT SQNR):')
+    for k, r in ranked_pt[-3:]:
+        print(f'    {k:60s}  {r["pretrain"]:.2f} dB')
+
+    # =========================================================
+    # 2. Bit-width sweep（验证 ~6 dB/bit）
+    # =========================================================
+    print(f'\n{"=" * 70}')
+    print(f'  Bit-width sweep on pretrain weights (avg across {len(w8_results)} Linears)')
+    print(f'  theory: SQNR ≈ 6.02 × bits + 1.76 dB (uniform quantizer, full-scale signal)')
+    print(f'{"=" * 70}')
+    sweep = measure_bit_sweep(pretrain_sd, bit_list=(2, 3, 4, 6, 8, 12))
+    prev = None
+    print(f"  {'bits':>5s} {'measured':>12s} {'theory (6b+1.76)':>18s} {'Δ vs prev':>12s}")
+    for bits, s in sweep.items():
+        theory = 6.02 * bits + 1.76
+        delta = f"{s - prev:+.2f} dB" if prev is not None else "—"
+        print(f"  {bits:>5d} {s:>10.2f}dB {theory:>15.2f}dB {delta:>12s}")
+        prev = s
+
+    # =========================================================
+    # 3. Activation SQNR（可选，需要 GPU + 数据）
+    # =========================================================
+    if args.act:
+        print(f'\n{"=" * 70}')
+        print(f'  Activation SQNR (per-tensor symmetric int8, running_max from QAT training)')
+        print(f'  用 {args.n_samples} 条 pretrain 样本走前向，hook 到每个 QATLinear 输入')
+        print(f'{"=" * 70}')
+        cfg = MiniMindConfig(hidden_size=args.hidden_size,
+                             num_hidden_layers=args.num_hidden_layers,
+                             use_moe=bool(args.use_moe))
+        act_sqnr, n_run = measure_activation_sqnr(
+            cfg, qat_path, args.tokenizer_path,
+            args.data_path, args.n_samples, args.device,
+        )
+        print(f'  (evaluated on {n_run} samples)')
+        # 按 attn/ffn 分组汇总
+        act_groups = {'attn': [], 'ffn': []}
+        for name, v in act_sqnr.items():
+            if 'self_attn' in name: act_groups['attn'].append(v)
+            elif 'mlp' in name: act_groups['ffn'].append(v)
+        print(f"  {'Group':10s} {'#Linear':>10s} {'A8 SQNR mean':>15s} {'min':>10s} {'max':>10s}")
+        for g, vs in act_groups.items():
+            if not vs: continue
+            print(f"  {g:10s} {len(vs):>10d} {sum(vs)/len(vs):>13.2f}dB {min(vs):>8.2f}dB {max(vs):>8.2f}dB")
+        # 层 0 明细
+        print(f'\n  Layer 0 per-Linear activation SQNR:')
+        for name, v in act_sqnr.items():
+            if 'layers.0.' not in name: continue
+            short = name.replace('model.layers.0.', '')
+            print(f'    {short:40s}  {v:.2f} dB')
+        # 全局最差 3 个
+        ranked_act = sorted(act_sqnr.items(), key=lambda kv: kv[1])
+        print(f'\n  Worst 3 activation SQNR (量化最难扛的层):')
+        for k, v in ranked_act[:3]:
+            print(f'    {k:60s}  {v:.2f} dB')
+
+    print(f'\n{"=" * 70}')
+    print(f'  参照：W8 通常 40-50 dB / W4 15-25 dB / <20 dB 开始明显掉 PPL')
+    print(f'{"=" * 70}')
+
+
+if __name__ == "__main__":
+    main()

--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -16,17 +16,23 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, DistributedSampler
 from model.model_minimind import MiniMindConfig
 from dataset.lm_dataset import SFTDataset
-from trainer.trainer_utils import get_lr, Logger, is_main_process, lm_checkpoint, init_distributed_mode, setup_seed, init_model, SkipBatchSampler
+from trainer.trainer_utils import (
+    get_lr, Logger, is_main_process, lm_checkpoint, init_distributed_mode,
+    setup_seed, init_model, SkipBatchSampler,
+    detect_gpu_peak_tflops_bf16, compute_model_flops_per_token,
+)
 
 warnings.filterwarnings('ignore')
 
 
 def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     start_time = time.time()
+    last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
-        input_ids = input_ids.to(args.device)
-        labels = labels.to(args.device)
+        # non_blocking 仅在 --enable_optimizations=1 + pin_memory=True 时有效
+        input_ids = input_ids.to(args.device, non_blocking=args.enable_optimizations == 1)
+        labels = labels.to(args.device, non_blocking=args.enable_optimizations == 1)
         last_step = step
         lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
         for param_group in optimizer.param_groups:
@@ -49,14 +55,21 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
             optimizer.zero_grad(set_to_none=True)
 
         if step % args.log_interval == 0 or step == iters:
-            spend_time = time.time() - start_time
+            now = time.time()
+            spend_time = now - start_time
+            window_dt = max(now - last_log_time, 1e-6)
+            window_steps = step - last_log_step
+            window_its = window_steps / window_dt
+            tokens_window = window_steps * args.batch_size * args.max_seq_len * world_size
+            mfu = (flops_per_token * tokens_window / window_dt) / (gpu_peak_tflops * 1e12) * 100
+            last_log_time, last_log_step = now, step
             current_loss = loss.item() * args.accumulation_steps
             current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
             current_logits_loss = current_loss - current_aux_loss
             current_lr = optimizer.param_groups[-1]['lr']
             eta_min = spend_time / max(step - start_step, 1) * (iters - step) // 60
-            Logger(f'Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
-            if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min})
+            Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, MFU: {mfu:.1f}%, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
+            if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min, "it/s": window_its, "MFU": mfu})
 
         if (step % args.save_interval == 0 or step == iters) and is_main_process():
             model.eval()
@@ -104,7 +117,13 @@ if __name__ == "__main__":
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
     parser.add_argument("--use_wandb", action="store_true", help="是否使用wandb")
     parser.add_argument("--wandb_project", type=str, default="MiniMind-Full-SFT", help="wandb项目名")
-    parser.add_argument("--use_compile", default=0, type=int, choices=[0, 1], help="是否使用torch.compile加速（0=否，1=是）")
+    parser.add_argument("--use_compile", default=1, type=int, choices=[0, 1],
+                        help="是否使用 torch.compile 加速（0=否，1=是，A100 上推荐 1）")
+    parser.add_argument("--enable_optimizations", default=1, type=int, choices=[0, 1],
+                        help="开关：A/B 对比优化效果。1=启用 fused AdamW + non_blocking + persistent_workers（默认）；"
+                             "0=baseline（关掉这些，仅保留 log 测量）。compile 由 --use_compile 独立控制。")
+    parser.add_argument("--gpu_peak_tflops", type=float, default=0,
+                        help="GPU bf16 理论峰值 TFLOPS（用于 MFU 计算）；默认 0 表示按 GPU 名自动检测")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========
@@ -136,8 +155,20 @@ if __name__ == "__main__":
     train_ds = SFTDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
-    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
-    
+    # fused=True 把所有 param 的 Adam 更新融成一个 CUDA kernel
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate,
+                            fused=(args.enable_optimizations == 1))
+
+    # ========== 5b. MFU 测量准备（始终启用，无 perf 影响）==========
+    flops_per_token = compute_model_flops_per_token(model, lm_config)
+    gpu_peak_tflops = detect_gpu_peak_tflops_bf16(override=args.gpu_peak_tflops)
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    Logger(f'[MFU] params_flops/token={flops_per_token/1e9:.3f} GFLOPS, '
+           f'GPU peak={gpu_peak_tflops:.0f} TFLOPS bf16, world_size={world_size}')
+    Logger(f'[OPT] enable_optimizations={args.enable_optimizations} '
+           f'(non_blocking={args.enable_optimizations}, fused_adam={args.enable_optimizations}, '
+           f'persistent_workers={args.enable_optimizations}), use_compile={args.use_compile}')
+
     # ========== 6. 从ckp恢复状态 ==========
     start_epoch, start_step = 0, 0
     if ckp_data:
@@ -149,8 +180,10 @@ if __name__ == "__main__":
     
     # ========== 7. 编译和分布式包装 ==========
     if args.use_compile == 1:
-        model = torch.compile(model)
-        Logger('torch.compile enabled')
+        # enable_optimizations=1 时用 max-autotune（找更优 kernel），0 时用 default mode
+        compile_mode = "max-autotune" if args.enable_optimizations == 1 else "default"
+        model = torch.compile(model, mode=compile_mode)
+        Logger(f'torch.compile enabled (mode={compile_mode})')
     if dist.is_initialized():
         model = DistributedDataParallel(model, device_ids=[local_rank])
     
@@ -160,7 +193,9 @@ if __name__ == "__main__":
         setup_seed(42 + epoch); indices = torch.randperm(len(train_ds)).tolist()
         skip = start_step if (epoch == start_epoch and start_step > 0) else 0
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
-        loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers, pin_memory=True)
+        loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers,
+                            pin_memory=True,
+                            persistent_workers=(args.enable_optimizations == 1 and args.num_workers > 0))
         if skip > 0: 
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
             train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)

--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -75,18 +75,23 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
             Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, MFU: {mfu:.1f}%, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
             if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min, "it/s": window_its, "MFU": mfu})
 
-        if (step % args.save_interval == 0 or step == iters) and is_main_process():
-            model.eval()
-            moe_suffix = '_moe' if lm_config.use_moe else ''
-            ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
-            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
-            raw_model = getattr(raw_model, '_orig_mod', raw_model)
-            state_dict = raw_model.state_dict()
-            torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp)
-            lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer, 
-                         epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints', scaler=scaler)
-            model.train()
-            del state_dict
+        if step % args.save_interval == 0 or step == iters:
+            if is_main_process():
+                model.eval()
+                moe_suffix = '_moe' if lm_config.use_moe else ''
+                ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+                raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+                raw_model = getattr(raw_model, '_orig_mod', raw_model)
+                state_dict = raw_model.state_dict()
+                ckp_tmp = ckp + '.tmp'
+                torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp_tmp)
+                os.replace(ckp_tmp, ckp)
+                lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer,
+                             epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints', scaler=scaler)
+                model.train()
+                del state_dict
+            if dist.is_initialized():
+                dist.barrier()
 
         del input_ids, labels, res, loss
 

--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -30,6 +30,10 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
+        # torch.compile(mode="max-autotune") + CUDA graph 每步必须 mark step 边界，
+        # 否则 backward 拿到被下一步 forward 覆盖的 tensor 报错。见 train_pretrain.py 同处注释。
+        if args.use_compile == 1:
+            torch.compiler.cudagraph_mark_step_begin()
         # non_blocking 仅在 --enable_optimizations=1 + pin_memory=True 时有效
         input_ids = input_ids.to(args.device, non_blocking=args.enable_optimizations == 1)
         labels = labels.to(args.device, non_blocking=args.enable_optimizations == 1)

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -23,6 +23,7 @@ warnings.filterwarnings('ignore')
 
 def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     start_time = time.time()
+    last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
         input_ids = input_ids.to(args.device)
@@ -49,13 +50,16 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
             optimizer.zero_grad(set_to_none=True)
 
         if step % args.log_interval == 0 or step == iters:
-            spend_time = time.time() - start_time
+            now = time.time()
+            spend_time = now - start_time
+            window_its = (step - last_log_step) / max(now - last_log_time, 1e-6)
+            last_log_time, last_log_step = now, step
             current_loss = loss.item() * args.accumulation_steps
             current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
             current_logits_loss = current_loss - current_aux_loss
             current_lr = optimizer.param_groups[-1]['lr']
             eta_min = spend_time / max(step - start_step, 1) * (iters - step) // 60
-            Logger(f'Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
+            Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
             if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min})
 
         if (step % args.save_interval == 0 or step == iters) and is_main_process():
@@ -103,7 +107,7 @@ if __name__ == "__main__":
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
     parser.add_argument("--use_wandb", action="store_true", help="是否使用wandb")
     parser.add_argument("--wandb_project", type=str, default="MiniMind-Pretrain", help="wandb项目名")
-    parser.add_argument("--use_compile", default=0, type=int, choices=[0, 1], help="是否使用torch.compile加速（0=否，1=是）")
+    parser.add_argument("--use_compile", default=1, type=int, choices=[0, 1], help="是否使用torch.compile加速（0=否，1=是，A100 上推荐默认 1）")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import datasets  # noqa: F401  # Windows pyarrow/torch DLL conflict workaround (issue #771)
 import argparse
+import math
 import time
 import warnings
 import torch
@@ -25,7 +26,32 @@ from trainer.trainer_utils import (
 warnings.filterwarnings('ignore')
 
 
-def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
+@torch.no_grad()
+def eval_holdout(model, eval_loader, max_batches, autocast_ctx, device):
+    """
+    rank-0 only 跑 holdout PPL；调用方需保证只 rank-0 进入。
+    返回 (avg_loss, ppl)。max_batches 控制 eval 时长（1B 时 20-50 batch 足够，~1s）。
+    """
+    was_training = model.training
+    model.eval()
+    total_loss, total_tokens = 0.0, 0
+    for i, (input_ids, labels) in enumerate(eval_loader):
+        if i >= max_batches: break
+        input_ids = input_ids.to(device, non_blocking=True)
+        labels = labels.to(device, non_blocking=True)
+        with autocast_ctx:
+            res = model(input_ids, labels=labels)
+        # loss 已经是 mean over non-pad tokens；乘 n_tokens 便于跨 batch weighted avg
+        n_tokens = (labels != -100).sum().item()
+        if n_tokens > 0:
+            total_loss += res.loss.item() * n_tokens
+            total_tokens += n_tokens
+    if was_training: model.train()
+    avg_loss = total_loss / max(total_tokens, 1)
+    return avg_loss, math.exp(avg_loss)
+
+
+def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None):
     start_time = time.time()
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
@@ -40,7 +66,7 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
         input_ids = input_ids.to(args.device, non_blocking=True)
         labels = labels.to(args.device, non_blocking=True)
         last_step = step
-        lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
+        lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate, args.warmup_steps)
         for param_group in optimizer.param_groups:
             param_group['lr'] = lr
 
@@ -79,17 +105,34 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
             Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, MFU: {mfu:.1f}%, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
             if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min})
 
-        if (step % args.save_interval == 0 or step == iters) and is_main_process():
-            model.eval()
-            moe_suffix = '_moe' if lm_config.use_moe else ''
-            ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
-            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
-            raw_model = getattr(raw_model, '_orig_mod', raw_model)
-            state_dict = raw_model.state_dict()
-            torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp)
-            lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer, scaler=scaler, epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints')
-            model.train()
-            del state_dict
+        # ---- eval loop（可选） ----
+        if args.eval_interval > 0 and step % args.eval_interval == 0 and eval_loader is not None:
+            if is_main_process():
+                val_loss, val_ppl = eval_holdout(model, eval_loader, args.eval_max_batches, autocast_ctx, args.device)
+                Logger(f'[eval] step={step} val_loss={val_loss:.4f} val_ppl={val_ppl:.2f}')
+                if wandb: wandb.log({"val_loss": val_loss, "val_ppl": val_ppl, "step": step})
+            if dist.is_initialized(): dist.barrier()
+
+        if step % args.save_interval == 0 or step == iters:
+            if is_main_process():
+                model.eval()
+                moe_suffix = '_moe' if lm_config.use_moe else ''
+                ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+                raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+                raw_model = getattr(raw_model, '_orig_mod', raw_model)
+                state_dict = raw_model.state_dict()
+                # atomic: tmp + rename 避免读者读到半写文件（当前的 torch.save 直接写不 atomic，
+                # 极端情况 kill -9 会留 corrupt ckpt；lm_checkpoint 内部已 atomic，此处也补上）
+                ckp_tmp = ckp + '.tmp'
+                torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp_tmp)
+                os.replace(ckp_tmp, ckp)
+                lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer, scaler=scaler, epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints')
+                model.train()
+                del state_dict
+            # 所有 rank 在此汇合，让非 rank-0 等 rank-0 写完再进下一 step
+            # （防止 NCCL 隐式同步下的 timing race，也确保 ckpt 文件对 resume 一致）
+            if dist.is_initialized():
+                dist.barrier()
 
         del input_ids, labels, res, loss
 
@@ -127,6 +170,17 @@ if __name__ == "__main__":
     parser.add_argument("--use_compile", default=1, type=int, choices=[0, 1], help="是否使用torch.compile加速（0=否，1=是，A100 上推荐默认 1）")
     parser.add_argument("--gpu_peak_tflops", type=float, default=0,
                         help="GPU bf16 理论峰值 TFLOPS，用于 MFU 计算；默认 0 表示按 GPU 名自动检测（A100=312）")
+    parser.add_argument("--warmup_steps", type=int, default=0,
+                        help="linear warmup 步数。1B from-scratch 建议 500-2000；64M 用现有 pretrain ckpt 微调设 0 即可")
+    parser.add_argument("--grad_checkpointing", type=int, default=0, choices=[0, 1],
+                        help="激活值 gradient checkpointing：省 30-50%% activation 显存，慢 ~30%%。"
+                             "1B + seq=1024 在 80GB 用不上；seq=2048 或 8B+ 或大 batch 时需要打开")
+    parser.add_argument("--eval_interval", type=int, default=0,
+                        help="每 N step 跑一次 holdout eval（0=关闭）。1B 建议 500-1000")
+    parser.add_argument("--eval_data_path", type=str, default=None,
+                        help="holdout jsonl 路径；不设则关闭 eval")
+    parser.add_argument("--eval_max_batches", type=int, default=20,
+                        help="每次 eval 最多跑几个 batch（20*batch_size 通常够 ~1s 内出数）")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========
@@ -155,6 +209,9 @@ if __name__ == "__main__":
 
     # ========== 5. 定义模型、数据、优化器 ==========
     model, tokenizer = init_model(lm_config, args.from_weight, device=args.device)
+    if args.grad_checkpointing == 1:
+        model.model.set_grad_checkpointing(True)
+        Logger('gradient checkpointing enabled (activation 省 30-50%%, 慢 ~30%%)')
     train_ds = PretrainDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
@@ -189,6 +246,16 @@ if __name__ == "__main__":
     if dist.is_initialized():
         model = DistributedDataParallel(model, device_ids=[local_rank])
 
+    # ========== 7b. eval loader（可选） ==========
+    eval_loader = None
+    if args.eval_interval > 0 and args.eval_data_path and is_main_process():
+        # rank-0 only：只 main rank 需要 eval loader（其他 rank barrier 等待）
+        eval_ds = PretrainDataset(args.eval_data_path, tokenizer, max_length=args.max_seq_len)
+        eval_loader = DataLoader(eval_ds, batch_size=args.batch_size,
+                                 shuffle=False, num_workers=2, pin_memory=True)
+        Logger(f'[eval] loader ready: {len(eval_ds)} samples from {args.eval_data_path}, '
+               f'eval_interval={args.eval_interval}, max_batches={args.eval_max_batches}')
+
     # ========== 8. 开始训练 ==========
     for epoch in range(start_epoch, args.epochs):
         train_sampler and train_sampler.set_epoch(epoch)
@@ -199,9 +266,9 @@ if __name__ == "__main__":
                             pin_memory=True, persistent_workers=args.num_workers > 0)
         if skip > 0:
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
-            train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)
+            train_epoch(epoch, loader, len(loader) + skip, start_step, wandb, eval_loader)
         else:
-            train_epoch(epoch, loader, len(loader), 0, wandb)
+            train_epoch(epoch, loader, len(loader), 0, wandb, eval_loader)
 
     # ========== 9. 清理分布进程 ==========
     if dist.is_initialized():

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -30,6 +30,12 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
+        # torch.compile(mode="max-autotune") 会启用 CUDA graph capture 复用输出 buffer；
+        # 训练循环里每步都是新 batch，必须显式 mark step 边界告诉 CUDAGraph "上一步的输出
+        # 现在不能再复用了"。否则 backward 拿到被覆盖的 tensor 报 "accessing tensor output
+        # of CUDAGraphs that has been overwritten" 错。torch 2.6+ 严格执行此检查。
+        if args.use_compile == 1:
+            torch.compiler.cudagraph_mark_step_begin()
         # non_blocking=True overlaps host->device copy with compute (pin_memory=True 已在 DataLoader)
         input_ids = input_ids.to(args.device, non_blocking=True)
         labels = labels.to(args.device, non_blocking=True)
@@ -113,7 +119,7 @@ if __name__ == "__main__":
     parser.add_argument('--num_hidden_layers', default=8, type=int, help="隐藏层数量")
     parser.add_argument('--max_seq_len', default=340, type=int, help="训练的最大截断长度（中文1token≈1.5~1.7字符）")
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
-    parser.add_argument("--data_path", type=str, default="../dataset/pretrain_t2t_mini.jsonl", help="预训练数据路径")
+    parser.add_argument("--data_path", type=str, default="../dataset/pretrain_t2t.jsonl", help="预训练数据路径")
     parser.add_argument('--from_weight', default='none', type=str, help="基于哪个权重训练，为none则从头开始")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
     parser.add_argument("--use_wandb", action="store_true", help="是否使用wandb")
@@ -127,17 +133,17 @@ if __name__ == "__main__":
     local_rank = init_distributed_mode()
     if dist.is_initialized(): args.device = f"cuda:{local_rank}"
     setup_seed(42 + (dist.get_rank() if dist.is_initialized() else 0))
-    
+
     # ========== 2. 配置目录、模型参数、检查ckp ==========
     os.makedirs(args.save_dir, exist_ok=True)
     lm_config = MiniMindConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe))
     ckp_data = lm_checkpoint(lm_config, weight=args.save_weight, save_dir='../checkpoints') if args.from_resume==1 else None
-    
+
     # ========== 3. 设置混合精度 ==========
     device_type = "cuda" if "cuda" in args.device else "cpu"
     dtype = torch.bfloat16 if args.dtype == "bfloat16" else torch.float16
     autocast_ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast(dtype=dtype)
-    
+
     # ========== 4. 配wandb ==========
     wandb = None
     if args.use_wandb and is_main_process():
@@ -146,7 +152,7 @@ if __name__ == "__main__":
         resume = 'must' if wandb_id else None
         wandb_run_name = f"MiniMind-Pretrain-Epoch-{args.epochs}-BatchSize-{args.batch_size}-LearningRate-{args.learning_rate}"
         wandb.init(project=args.wandb_project, name=wandb_run_name, id=wandb_id, resume=resume)
-    
+
     # ========== 5. 定义模型、数据、优化器 ==========
     model, tokenizer = init_model(lm_config, args.from_weight, device=args.device)
     train_ds = PretrainDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
@@ -170,16 +176,19 @@ if __name__ == "__main__":
         scaler.load_state_dict(ckp_data['scaler'])
         start_epoch = ckp_data['epoch']
         start_step = ckp_data.get('step', 0)
-    
+
     # ========== 7. 编译和分布式包装 ==========
     if args.use_compile == 1:
-        # max-autotune 在 Triton 层为每个 fused kernel 试多套 tile/block 配置，挑最快的。
-        # 编译时间多 ~30-60s，稳态可比 default 快 5-15%。
-        model = torch.compile(model, mode="max-autotune")
-        Logger('torch.compile enabled (mode=max-autotune)')
+        # 新 CUDA 13 stack 上 max-autotune 会为每个 GEMM shape 试 21 种 triton kernel（分钟级
+        # autotune 循环，且实测 cuBLAS aten mm 几乎每次都赢过 triton 变体，autotune 白花时间）。
+        # 用 default 更实惠——inductor 融合仍在，只是不额外扫 triton kernel。
+        # (max-autotune 还需要 model 无 graph break，否则 CUDA graph 跨 step 覆盖崩溃；
+        # 我们已消除 RoPE graph break，若将来单独 GEMM shape 少可再试 max-autotune)
+        model = torch.compile(model)
+        Logger('torch.compile enabled (mode=default)')
     if dist.is_initialized():
         model = DistributedDataParallel(model, device_ids=[local_rank])
-    
+
     # ========== 8. 开始训练 ==========
     for epoch in range(start_epoch, args.epochs):
         train_sampler and train_sampler.set_epoch(epoch)
@@ -188,12 +197,12 @@ if __name__ == "__main__":
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
         loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers,
                             pin_memory=True, persistent_workers=args.num_workers > 0)
-        if skip > 0: 
+        if skip > 0:
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
             train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)
         else:
             train_epoch(epoch, loader, len(loader), 0, wandb)
-    
+
     # ========== 9. 清理分布进程 ==========
     if dist.is_initialized():
         dist.barrier()

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -51,7 +51,7 @@ def eval_holdout(model, eval_loader, max_batches, autocast_ctx, device):
     return avg_loss, math.exp(avg_loss)
 
 
-def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None):
+def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None, profiler=None):
     start_time = time.time()
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
@@ -70,12 +70,21 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
         for param_group in optimizer.param_groups:
             param_group['lr'] = lr
 
-        with autocast_ctx:
-            res = model(input_ids, labels=labels)
-            loss = res.loss + res.aux_loss
-            loss = loss / args.accumulation_steps
+        # DDP gradient accumulation optimization：
+        # 默认 DDP 每次 .backward() 都做全参数 all-reduce（4GB grad × 85 bucket ≈ 30ms）。
+        # 但 accum=N 时前 N-1 次 all-reduce 是浪费（grad 还要继续累积）。用 model.no_sync()
+        # 让 DDP 在非最后一个 micro-step 里 skip all-reduce，只在最后一个 micro-step 才同步。
+        # profile 显示 all-reduce 占 73% 时间 → 修完预期总时间省 ~55%，MFU 17%→~35%。
+        is_last_accum_step = (step % args.accumulation_steps == 0)
+        need_sync = is_last_accum_step or not isinstance(model, DistributedDataParallel)
+        sync_ctx = nullcontext() if need_sync else model.no_sync()
 
-        scaler.scale(loss).backward()
+        with sync_ctx:
+            with autocast_ctx:
+                res = model(input_ids, labels=labels)
+                loss = res.loss + res.aux_loss
+                loss = loss / args.accumulation_steps
+            scaler.scale(loss).backward()
 
         if step % args.accumulation_steps == 0:
             scaler.unscale_(optimizer)
@@ -86,16 +95,24 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
 
             optimizer.zero_grad(set_to_none=True)
 
+        # profiler step 打点（每 step 一次；schedule 决定何时真的记录）
+        if profiler is not None:
+            profiler.step()
+
         if step % args.log_interval == 0 or step == iters:
             now = time.time()
             spend_time = now - start_time
             window_dt = max(now - last_log_time, 1e-6)
             window_steps = step - last_log_step
             window_its = window_steps / window_dt
-            # MFU = 实际 FLOPs/s / GPU 峰值；按 window 内的 token 吞吐算（避开 warmup / ckpt save 污染）
-            # tokens 用 per-rank batch × seq_len × world_size × window_steps（DDP 每卡同时处理 batch）
+            # MFU = per-card 实际 FLOPs/s / per-card 峰值。分子分母都要一致口径：
+            # - 分子: 4 卡总 tokens × flops/token = 总 flops；÷ world_size 得 per-card flops
+            # - 分母: gpu_peak_tflops (单卡峰值，312 TFLOPS on A100)
+            # 早期版本 bug：分子用全部 tokens 但分母只除 1 卡峰值 → 报数是真实 MFU 的 world_size 倍。
             tokens_window = window_steps * args.batch_size * args.max_seq_len * world_size
-            mfu = (flops_per_token * tokens_window / window_dt) / (gpu_peak_tflops * 1e12) * 100
+            total_flops_per_s = flops_per_token * tokens_window / window_dt
+            per_card_flops_per_s = total_flops_per_s / world_size
+            mfu = per_card_flops_per_s / (gpu_peak_tflops * 1e12) * 100
             last_log_time, last_log_step = now, step
             current_loss = loss.item() * args.accumulation_steps
             current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
@@ -107,11 +124,23 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
 
         # ---- eval loop（可选） ----
         if args.eval_interval > 0 and step % args.eval_interval == 0 and eval_loader is not None:
+            # ⚠️ 全 rank 都跑 eval：单 rank eval (即使 unwrap raw model) 也会导致 DDP guard 失效 /
+            # torch.compile recompile → rank 0 长 stall → 下一步 all-reduce seq 不同步 → NCCL 10min timeout。
+            # 解决：所有 rank 用同一份 eval_loader (顺序一致) 跑同样的 batch，然后 all-reduce mean loss。
+            # 每 rank 都工作，无 rank 掉队问题。max_batches=20 * 5 rank = 20 batch × ~0.3s ≈ 6s 开销。
+            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+            raw_model = getattr(raw_model, '_orig_mod', raw_model)
+            val_loss_local, _ = eval_holdout(raw_model, eval_loader, args.eval_max_batches, autocast_ctx, args.device)
+            if dist.is_initialized():
+                loss_t = torch.tensor(val_loss_local, device=args.device)
+                dist.all_reduce(loss_t, op=dist.ReduceOp.AVG)
+                val_loss = loss_t.item()
+            else:
+                val_loss = val_loss_local
+            val_ppl = math.exp(val_loss)
             if is_main_process():
-                val_loss, val_ppl = eval_holdout(model, eval_loader, args.eval_max_batches, autocast_ctx, args.device)
                 Logger(f'[eval] step={step} val_loss={val_loss:.4f} val_ppl={val_ppl:.2f}')
                 if wandb: wandb.log({"val_loss": val_loss, "val_ppl": val_ppl, "step": step})
-            if dist.is_initialized(): dist.barrier()
 
         if step % args.save_interval == 0 or step == iters:
             if is_main_process():
@@ -181,6 +210,11 @@ if __name__ == "__main__":
                         help="holdout jsonl 路径；不设则关闭 eval")
     parser.add_argument("--eval_max_batches", type=int, default=20,
                         help="每次 eval 最多跑几个 batch（20*batch_size 通常够 ~1s 内出数）")
+    parser.add_argument("--profile_steps", type=int, default=0,
+                        help="torch.profiler 抓 N 步（0=关）；建议 20。会在 wait=10 warmup=5 active=N 后自动退出。"
+                             "trace 存到 --profile_out 目录，chrome://tracing 打开或 tensorboard --logdir profile_out")
+    parser.add_argument("--profile_out", type=str, default="../profile_out",
+                        help="profile trace 输出目录")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========
@@ -247,16 +281,34 @@ if __name__ == "__main__":
         model = DistributedDataParallel(model, device_ids=[local_rank])
 
     # ========== 7b. eval loader（可选） ==========
+    # 全 rank 都建 eval loader（不能只 rank 0，否则 all-reduce 时 rank 1/2/3 无 eval loss 参与聚合）
     eval_loader = None
-    if args.eval_interval > 0 and args.eval_data_path and is_main_process():
-        # rank-0 only：只 main rank 需要 eval loader（其他 rank barrier 等待）
+    if args.eval_interval > 0 and args.eval_data_path:
         eval_ds = PretrainDataset(args.eval_data_path, tokenizer, max_length=args.max_seq_len)
+        # 所有 rank 用同一份数据 + shuffle=False → 保证跑相同 batch → all-reduce 有意义
         eval_loader = DataLoader(eval_ds, batch_size=args.batch_size,
                                  shuffle=False, num_workers=2, pin_memory=True)
         Logger(f'[eval] loader ready: {len(eval_ds)} samples from {args.eval_data_path}, '
                f'eval_interval={args.eval_interval}, max_batches={args.eval_max_batches}')
 
+    # ========== 7c. profiler（可选） ==========
+    profiler_ctx = None
+    if args.profile_steps > 0 and is_main_process():
+        # schedule: 前 10 步 warmup（skip compile 编译期），5 步观察，profile_steps 步真记录
+        from torch.profiler import profile, schedule, ProfilerActivity, tensorboard_trace_handler
+        os.makedirs(args.profile_out, exist_ok=True)
+        profiler_ctx = profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+            schedule=schedule(wait=10, warmup=5, active=args.profile_steps, repeat=1),
+            on_trace_ready=tensorboard_trace_handler(args.profile_out),
+            record_shapes=True, with_stack=False, with_flops=False,
+        )
+        Logger(f'[profile] enabled: warmup 15 step → capture {args.profile_steps} step → trace to {args.profile_out}')
+        Logger('[profile] 训练完 profile 步后不自动退出——手动 Ctrl+C 停即可。trace 已 flush 到磁盘。')
+
     # ========== 8. 开始训练 ==========
+    if profiler_ctx is not None:
+        profiler_ctx.__enter__()
     for epoch in range(start_epoch, args.epochs):
         train_sampler and train_sampler.set_epoch(epoch)
         setup_seed(42 + epoch); indices = torch.randperm(len(train_ds)).tolist()
@@ -266,9 +318,11 @@ if __name__ == "__main__":
                             pin_memory=True, persistent_workers=args.num_workers > 0)
         if skip > 0:
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
-            train_epoch(epoch, loader, len(loader) + skip, start_step, wandb, eval_loader)
+            train_epoch(epoch, loader, len(loader) + skip, start_step, wandb, eval_loader, profiler_ctx)
         else:
-            train_epoch(epoch, loader, len(loader), 0, wandb, eval_loader)
+            train_epoch(epoch, loader, len(loader), 0, wandb, eval_loader, profiler_ctx)
+    if profiler_ctx is not None:
+        profiler_ctx.__exit__(None, None, None)
 
     # ========== 9. 清理分布进程 ==========
     if dist.is_initialized():

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -70,13 +70,14 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
         for param_group in optimizer.param_groups:
             param_group['lr'] = lr
 
-        # DDP gradient accumulation optimization：
-        # 默认 DDP 每次 .backward() 都做全参数 all-reduce（4GB grad × 85 bucket ≈ 30ms）。
-        # 但 accum=N 时前 N-1 次 all-reduce 是浪费（grad 还要继续累积）。用 model.no_sync()
-        # 让 DDP 在非最后一个 micro-step 里 skip all-reduce，只在最后一个 micro-step 才同步。
-        # profile 显示 all-reduce 占 73% 时间 → 修完预期总时间省 ~55%，MFU 17%→~35%。
+        # DDP / FSDP gradient accumulation optimization：
+        # 默认每次 .backward() 都做全参数 collective（DDP: all-reduce grad；FSDP: reduce-scatter grad）。
+        # 但 accum=N 时前 N-1 次 collective 是浪费（grad 还要继续累积）。DDP.no_sync() 和 FSDP.no_sync()
+        # 都提供 context 让 collective 只在最后一个 micro-step 才触发。
+        # profile 显示（DDP）all-reduce 占 73% 时间 → 修完预期总时间省 ~55%，MFU 17%→~35%。
         is_last_accum_step = (step % args.accumulation_steps == 0)
-        need_sync = is_last_accum_step or not isinstance(model, DistributedDataParallel)
+        has_no_sync = callable(getattr(model, 'no_sync', None))
+        need_sync = is_last_accum_step or not has_no_sync
         sync_ctx = nullcontext() if need_sync else model.no_sync()
 
         with sync_ctx:
@@ -128,9 +129,21 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
             # torch.compile recompile → rank 0 长 stall → 下一步 all-reduce seq 不同步 → NCCL 10min timeout。
             # 解决：所有 rank 用同一份 eval_loader (顺序一致) 跑同样的 batch，然后 all-reduce mean loss。
             # 每 rank 都工作，无 rank 掉队问题。max_batches=20 * 5 rank = 20 batch × ~0.3s ≈ 6s 开销。
-            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
-            raw_model = getattr(raw_model, '_orig_mod', raw_model)
-            val_loss_local, _ = eval_holdout(raw_model, eval_loader, args.eval_max_batches, autocast_ctx, args.device)
+            #
+            # DDP: unwrap 拿裸 model（避免走 DDP forward 的 hook 触发 collective）
+            # FSDP: 不能 unwrap！FSDP forward 负责 all-gather 分片的 weight，unwrap 后 weight 不完整。
+            #       FSDP.forward 天然要求所有 rank 参与——正好符合我们的全-rank eval 设计
+            try:
+                from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+                is_fsdp = isinstance(model, FSDP)
+            except ImportError:
+                is_fsdp = False
+            if is_fsdp:
+                eval_model = model
+            else:
+                eval_model = model.module if isinstance(model, DistributedDataParallel) else model
+                eval_model = getattr(eval_model, '_orig_mod', eval_model)
+            val_loss_local, _ = eval_holdout(eval_model, eval_loader, args.eval_max_batches, autocast_ctx, args.device)
             if dist.is_initialized():
                 loss_t = torch.tensor(val_loss_local, device=args.device)
                 dist.all_reduce(loss_t, op=dist.ReduceOp.AVG)
@@ -143,21 +156,46 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None, eval_loader=None
                 if wandb: wandb.log({"val_loss": val_loss, "val_ppl": val_ppl, "step": step})
 
         if step % args.save_interval == 0 or step == iters:
-            if is_main_process():
-                model.eval()
-                moe_suffix = '_moe' if lm_config.use_moe else ''
-                ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
-                raw_model = model.module if isinstance(model, DistributedDataParallel) else model
-                raw_model = getattr(raw_model, '_orig_mod', raw_model)
-                state_dict = raw_model.state_dict()
-                # atomic: tmp + rename 避免读者读到半写文件（当前的 torch.save 直接写不 atomic，
-                # 极端情况 kill -9 会留 corrupt ckpt；lm_checkpoint 内部已 atomic，此处也补上）
-                ckp_tmp = ckp + '.tmp'
-                torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp_tmp)
-                os.replace(ckp_tmp, ckp)
-                lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer, scaler=scaler, epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints')
-                model.train()
-                del state_dict
+            # FSDP: 拿 full state_dict 是 collective，所有 rank 必须进入 FSDP.state_dict_type 上下文；
+            # 只 rank 0 通过 rank0_only=True 拿到实际数据，其他 rank 拿空 dict。
+            # DDP: 单 rank 就能拿完整 state_dict。
+            try:
+                from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+                is_fsdp = isinstance(model, FSDP)
+            except ImportError:
+                is_fsdp = False
+
+            if is_fsdp:
+                from torch.distributed.fsdp import StateDictType, FullStateDictConfig
+                cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+                with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, cfg):
+                    state_dict = model.state_dict()   # 所有 rank 调用（collective），只 rank 0 拿到完整
+                # rank 0 才写盘
+                if is_main_process() and state_dict:
+                    moe_suffix = '_moe' if lm_config.use_moe else ''
+                    ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+                    ckp_tmp = ckp + '.tmp'
+                    torch.save({k: v.half() for k, v in state_dict.items()}, ckp_tmp)
+                    os.replace(ckp_tmp, ckp)
+                    # 注意：FSDP 下 optimizer state 也是分片的，简化起见此处不存 optimizer resume
+                    # （resume 会从头 warmup 起，接受此代价换代码简单）
+                    del state_dict
+            else:
+                if is_main_process():
+                    model.eval()
+                    moe_suffix = '_moe' if lm_config.use_moe else ''
+                    ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+                    raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+                    raw_model = getattr(raw_model, '_orig_mod', raw_model)
+                    state_dict = raw_model.state_dict()
+                    # atomic: tmp + rename 避免读者读到半写文件（当前的 torch.save 直接写不 atomic，
+                    # 极端情况 kill -9 会留 corrupt ckpt；lm_checkpoint 内部已 atomic，此处也补上）
+                    ckp_tmp = ckp + '.tmp'
+                    torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp_tmp)
+                    os.replace(ckp_tmp, ckp)
+                    lm_checkpoint(lm_config, weight=args.save_weight, model=model, optimizer=optimizer, scaler=scaler, epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints')
+                    model.train()
+                    del state_dict
             # 所有 rank 在此汇合，让非 rank-0 等 rank-0 写完再进下一 step
             # （防止 NCCL 隐式同步下的 timing race，也确保 ckpt 文件对 resume 一致）
             if dist.is_initialized():
@@ -215,6 +253,15 @@ if __name__ == "__main__":
                              "trace 存到 --profile_out 目录，chrome://tracing 打开或 tensorboard --logdir profile_out")
     parser.add_argument("--profile_out", type=str, default="../profile_out",
                         help="profile trace 输出目录")
+    parser.add_argument("--parallel_strategy", type=str, default="ddp",
+                        choices=["ddp", "fsdp_full", "fsdp_grad_op", "fsdp_no", "tp"],
+                        help="分布式策略：ddp=DataParallel（默认）· fsdp_full=ZeRO-3（切 weight+grad+optim）· "
+                             "fsdp_grad_op=ZeRO-2（切 grad+optim，weight 复制）· fsdp_no=NO_SHARD（等价 DDP，用 FSDP wrap 走一遍）· "
+                             "tp=Tensor Parallel（用 PyTorch DTensor 切每层 Linear）"
+                             "。对比数据见 Design Doc #2。1B 用 DDP 足够；FSDP/TP 主要是学习/对比用途")
+    parser.add_argument("--tp_size", type=int, default=1,
+                        help="Tensor Parallel size（仅当 parallel_strategy=tp 时生效）。world_size 必须能整除 tp_size；"
+                             "dp_size = world_size / tp_size。例如 4 卡 tp_size=4 → 纯 TP=4；tp_size=2 → TP=2 × DP=2")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========
@@ -278,7 +325,91 @@ if __name__ == "__main__":
         model = torch.compile(model)
         Logger('torch.compile enabled (mode=default)')
     if dist.is_initialized():
-        model = DistributedDataParallel(model, device_ids=[local_rank])
+        if args.parallel_strategy == "ddp":
+            model = DistributedDataParallel(model, device_ids=[local_rank])
+            Logger('parallel strategy: DDP (每 rank 全参数复制)')
+        elif args.parallel_strategy == "tp":
+            # Tensor Parallel with PyTorch DTensor：把 Attention 和 MLP 的 Linear 切到 tp_size 卡上
+            # 关键：需要先修 Attention 里的 n_local_heads / n_local_kv_heads（每卡本地头数减少），
+            # 再用 parallelize_module 把 weight 切开。否则 xq.view(bsz, seq, n_local_heads, head_dim)
+            # 会因为 q_proj 输出宽度已经被切成 hidden/tp_size 而 shape mismatch。
+            from torch.distributed.tensor.parallel import (
+                parallelize_module, ColwiseParallel, RowwiseParallel
+            )
+            from torch.distributed.device_mesh import init_device_mesh
+            world_size_actual = dist.get_world_size()
+            tp_size = args.tp_size
+            dp_size = world_size_actual // tp_size
+            if tp_size * dp_size != world_size_actual:
+                raise ValueError(f"world_size {world_size_actual} 不能被 tp_size {tp_size} 整除")
+            # GQA 校验：kv_heads 必须能被 tp_size 整除，否则某 rank 分到 0.x 个 kv head 会崩
+            if lm_config.num_key_value_heads % tp_size != 0:
+                raise ValueError(f"num_key_value_heads={lm_config.num_key_value_heads} 不能被 tp_size={tp_size} 整除")
+            mesh = init_device_mesh("cuda", (dp_size, tp_size), mesh_dim_names=("dp", "tp"))
+            tp_mesh = mesh["tp"]
+            # 修正 Attention 的本地头数（否则 forward 里 view 会 shape 错）
+            raw_model_for_tp = model  # 此时还未 compile / wrap
+            for layer in raw_model_for_tp.model.layers:
+                layer.self_attn.n_local_heads = lm_config.num_attention_heads // tp_size
+                layer.self_attn.n_local_kv_heads = lm_config.num_key_value_heads // tp_size
+                # n_rep = n_local_heads // n_local_kv_heads，两边都除 tp_size 后比例不变，无需改
+            # 应用 TP 切分：q/k/v/gate/up 列切（out 维），o/down 行切（in 维）
+            tp_plan = {
+                "self_attn.q_proj": ColwiseParallel(),
+                "self_attn.k_proj": ColwiseParallel(),
+                "self_attn.v_proj": ColwiseParallel(),
+                "self_attn.o_proj": RowwiseParallel(),
+                "mlp.gate_proj":    ColwiseParallel(),
+                "mlp.up_proj":      ColwiseParallel(),
+                "mlp.down_proj":    RowwiseParallel(),
+            }
+            for layer in raw_model_for_tp.model.layers:
+                parallelize_module(layer, tp_mesh, tp_plan)
+            # DP wrap（若 dp_size > 1）：DDP over TP groups
+            if dp_size > 1:
+                dp_mesh = mesh["dp"]
+                # 用 dp_mesh 的 process group 建 DDP
+                model = DistributedDataParallel(
+                    model, device_ids=[local_rank], process_group=dp_mesh.get_group(),
+                )
+            Logger(f'parallel strategy: TP={tp_size} × DP={dp_size} (world={world_size_actual})')
+            Logger('⚠️  TP 是 experimental：ckpt 保存尚未处理 DTensor（--save_interval 0 关闭 save；如需 save 请等 Month 2）')
+        else:
+            # FSDP 三档：分别对应 ZeRO-3 / ZeRO-2 / DDP-等价
+            from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+            from torch.distributed.fsdp import ShardingStrategy, MixedPrecision, BackwardPrefetch
+            from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+            from functools import partial
+            from model.model_minimind import MiniMindBlock
+            strategy_map = {
+                "fsdp_full":    ShardingStrategy.FULL_SHARD,     # ZeRO-3: weight + grad + optim 都切
+                "fsdp_grad_op": ShardingStrategy.SHARD_GRAD_OP,  # ZeRO-2: grad + optim 切，weight 复制
+                "fsdp_no":      ShardingStrategy.NO_SHARD,       # 等价 DDP，走 FSDP 代码路径便于对比
+            }
+            # bf16 混合精度：param bf16 forward，reduce fp32 保证 grad 数值稳定
+            mixed_precision = MixedPrecision(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+                buffer_dtype=torch.float32,
+            )
+            # auto_wrap 每个 MiniMindBlock 单独作为 FSDP unit（不是整个 model 一个 unit）
+            # 这样 all_gather 是每层触发，粒度更细，memory peak 更低
+            auto_wrap_policy = partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={MiniMindBlock},
+            )
+            model = FSDP(
+                model,
+                sharding_strategy=strategy_map[args.parallel_strategy],
+                mixed_precision=mixed_precision,
+                auto_wrap_policy=auto_wrap_policy,
+                device_id=local_rank,
+                forward_prefetch=True,                              # 提前 all-gather 下一层 weight
+                backward_prefetch=BackwardPrefetch.BACKWARD_PRE,    # 提前 all-gather backward 需要的 weight
+                use_orig_params=True,                               # 兼容 torch.compile 和 param_groups
+            )
+            Logger(f'parallel strategy: FSDP {args.parallel_strategy} '
+                   f'({strategy_map[args.parallel_strategy].name})')
 
     # ========== 7b. eval loader（可选） ==========
     # 全 rank 都建 eval loader（不能只 rank 0，否则 all-reduce 时 rank 1/2/3 无 eval loss 参与聚合）

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -16,7 +16,11 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, DistributedSampler
 from model.model_minimind import MiniMindConfig
 from dataset.lm_dataset import PretrainDataset
-from trainer.trainer_utils import get_lr, Logger, is_main_process, lm_checkpoint, init_distributed_mode, setup_seed, init_model, SkipBatchSampler
+from trainer.trainer_utils import (
+    get_lr, Logger, is_main_process, lm_checkpoint, init_distributed_mode,
+    setup_seed, init_model, SkipBatchSampler,
+    detect_gpu_peak_tflops_bf16, compute_model_flops_per_token,
+)
 
 warnings.filterwarnings('ignore')
 
@@ -26,8 +30,9 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
-        input_ids = input_ids.to(args.device)
-        labels = labels.to(args.device)
+        # non_blocking=True overlaps host->device copy with compute (pin_memory=True 已在 DataLoader)
+        input_ids = input_ids.to(args.device, non_blocking=True)
+        labels = labels.to(args.device, non_blocking=True)
         last_step = step
         lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
         for param_group in optimizer.param_groups:
@@ -52,14 +57,20 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
         if step % args.log_interval == 0 or step == iters:
             now = time.time()
             spend_time = now - start_time
-            window_its = (step - last_log_step) / max(now - last_log_time, 1e-6)
+            window_dt = max(now - last_log_time, 1e-6)
+            window_steps = step - last_log_step
+            window_its = window_steps / window_dt
+            # MFU = 实际 FLOPs/s / GPU 峰值；按 window 内的 token 吞吐算（避开 warmup / ckpt save 污染）
+            # tokens 用 per-rank batch × seq_len × world_size × window_steps（DDP 每卡同时处理 batch）
+            tokens_window = window_steps * args.batch_size * args.max_seq_len * world_size
+            mfu = (flops_per_token * tokens_window / window_dt) / (gpu_peak_tflops * 1e12) * 100
             last_log_time, last_log_step = now, step
             current_loss = loss.item() * args.accumulation_steps
             current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
             current_logits_loss = current_loss - current_aux_loss
             current_lr = optimizer.param_groups[-1]['lr']
             eta_min = spend_time / max(step - start_step, 1) * (iters - step) // 60
-            Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
+            Logger(f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), it/s: {window_its:.2f}, MFU: {mfu:.1f}%, loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, epoch_time: {eta_min:.1f}min')
             if wandb: wandb.log({"loss": current_loss, "logits_loss": current_logits_loss, "aux_loss": current_aux_loss, "learning_rate": current_lr, "epoch_time": eta_min})
 
         if (step % args.save_interval == 0 or step == iters) and is_main_process():
@@ -108,6 +119,8 @@ if __name__ == "__main__":
     parser.add_argument("--use_wandb", action="store_true", help="是否使用wandb")
     parser.add_argument("--wandb_project", type=str, default="MiniMind-Pretrain", help="wandb项目名")
     parser.add_argument("--use_compile", default=1, type=int, choices=[0, 1], help="是否使用torch.compile加速（0=否，1=是，A100 上推荐默认 1）")
+    parser.add_argument("--gpu_peak_tflops", type=float, default=0,
+                        help="GPU bf16 理论峰值 TFLOPS，用于 MFU 计算；默认 0 表示按 GPU 名自动检测（A100=312）")
     args = parser.parse_args()
 
     # ========== 1. 初始化环境和随机种子 ==========
@@ -139,8 +152,16 @@ if __name__ == "__main__":
     train_ds = PretrainDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
-    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
-    
+    # fused=True 把所有 param 的 Adam 更新融成一个 CUDA kernel（A100/3090 + CUDA tensor 支持）
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate, fused=True)
+
+    # ========== 5b. MFU 测量准备 ==========
+    flops_per_token = compute_model_flops_per_token(model, lm_config)
+    gpu_peak_tflops = detect_gpu_peak_tflops_bf16(override=args.gpu_peak_tflops)
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    Logger(f'[MFU] params_flops/token={flops_per_token/1e9:.3f} GFLOPS, '
+           f'GPU peak={gpu_peak_tflops:.0f} TFLOPS bf16, world_size={world_size}')
+
     # ========== 6. 从ckp恢复状态 ==========
     start_epoch, start_step = 0, 0
     if ckp_data:
@@ -152,8 +173,10 @@ if __name__ == "__main__":
     
     # ========== 7. 编译和分布式包装 ==========
     if args.use_compile == 1:
-        model = torch.compile(model)
-        Logger('torch.compile enabled')
+        # max-autotune 在 Triton 层为每个 fused kernel 试多套 tile/block 配置，挑最快的。
+        # 编译时间多 ~30-60s，稳态可比 default 快 5-15%。
+        model = torch.compile(model, mode="max-autotune")
+        Logger('torch.compile enabled (mode=max-autotune)')
     if dist.is_initialized():
         model = DistributedDataParallel(model, device_ids=[local_rank])
     
@@ -163,7 +186,8 @@ if __name__ == "__main__":
         setup_seed(42 + epoch); indices = torch.randperm(len(train_ds)).tolist()
         skip = start_step if (epoch == start_epoch and start_step > 0) else 0
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
-        loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers, pin_memory=True)
+        loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers,
+                            pin_memory=True, persistent_workers=args.num_workers > 0)
         if skip > 0: 
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
             train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)

--- a/trainer/train_qat.py
+++ b/trainer/train_qat.py
@@ -31,6 +31,10 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
+        # torch.compile + CUDA graph 每步必须 mark step 边界，见 train_pretrain.py 同处注释。
+        # QAT 默认 --use_compile 0（fake-quant 阻断 fusion，即使开也少受益），此处保护性写入。
+        if args.use_compile == 1:
+            torch.compiler.cudagraph_mark_step_begin()
         input_ids = input_ids.to(args.device, non_blocking=True)
         labels = labels.to(args.device, non_blocking=True)
         last_step = step

--- a/trainer/train_qat.py
+++ b/trainer/train_qat.py
@@ -1,0 +1,221 @@
+import os
+import sys
+
+__package__ = "trainer"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import datasets  # noqa: F401  # Windows pyarrow/torch DLL conflict workaround (issue #771)
+import argparse
+import time
+import warnings
+import torch
+import torch.distributed as dist
+from contextlib import nullcontext
+from torch import optim
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, DistributedSampler
+from model.model_minimind import MiniMindConfig
+from model.quant import prepare_qat, DEFAULT_SKIP_PATTERNS
+from dataset.lm_dataset import SFTDataset
+from trainer.trainer_utils import (
+    get_lr, Logger, is_main_process, lm_checkpoint,
+    init_distributed_mode, setup_seed, init_model, SkipBatchSampler,
+)
+
+warnings.filterwarnings('ignore')
+
+
+def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
+    start_time = time.time()
+    last_step = start_step
+    for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
+        input_ids = input_ids.to(args.device)
+        labels = labels.to(args.device)
+        last_step = step
+        lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
+        for param_group in optimizer.param_groups:
+            param_group['lr'] = lr
+
+        with autocast_ctx:
+            res = model(input_ids, labels=labels)
+            loss = res.loss + res.aux_loss
+            loss = loss / args.accumulation_steps
+
+        scaler.scale(loss).backward()
+
+        if step % args.accumulation_steps == 0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad(set_to_none=True)
+
+        if step % args.log_interval == 0 or step == iters:
+            spend_time = time.time() - start_time
+            current_loss = loss.item() * args.accumulation_steps
+            current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
+            current_logits_loss = current_loss - current_aux_loss
+            current_lr = optimizer.param_groups[-1]['lr']
+            eta_min = spend_time / max(step - start_step, 1) * (iters - step) // 60
+            Logger(
+                f'Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), '
+                f'loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, '
+                f'aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, '
+                f'epoch_time: {eta_min:.1f}min'
+            )
+            if wandb:
+                wandb.log({
+                    "loss": current_loss, "logits_loss": current_logits_loss,
+                    "aux_loss": current_aux_loss, "learning_rate": current_lr,
+                    "epoch_time": eta_min,
+                })
+
+        if (step % args.save_interval == 0 or step == iters) and is_main_process():
+            model.eval()
+            moe_suffix = '_moe' if lm_config.use_moe else ''
+            ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+            raw_model = getattr(raw_model, '_orig_mod', raw_model)
+            state_dict = raw_model.state_dict()
+            torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp)
+            lm_checkpoint(
+                lm_config, weight=args.save_weight, model=model, optimizer=optimizer,
+                epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints', scaler=scaler,
+            )
+            model.train()
+            del state_dict
+
+        del input_ids, labels, res, loss
+
+    if last_step > start_step and last_step % args.accumulation_steps != 0:
+        scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
+        scaler.step(optimizer)
+        scaler.update()
+        optimizer.zero_grad(set_to_none=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MiniMind QAT (W8A8 fake-quant fine-tune)")
+    parser.add_argument("--save_dir", type=str, default="../out")
+    parser.add_argument('--save_weight', default='qat', type=str)
+    parser.add_argument("--epochs", type=int, default=1, help="QAT 通常 1~2 epoch 即可")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--learning_rate", type=float, default=2e-6,
+                        help="QAT 用比 SFT 更小的 lr（默认 1/5），防止打乱已收敛的权重分布")
+    parser.add_argument("--device", type=str, default="cuda:0" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--num_workers", type=int, default=8)
+    parser.add_argument("--accumulation_steps", type=int, default=1)
+    parser.add_argument("--grad_clip", type=float, default=1.0)
+    parser.add_argument("--log_interval", type=int, default=100)
+    parser.add_argument("--save_interval", type=int, default=1000)
+    parser.add_argument('--hidden_size', default=768, type=int)
+    parser.add_argument('--num_hidden_layers', default=8, type=int)
+    parser.add_argument('--max_seq_len', default=768, type=int)
+    parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1])
+    parser.add_argument("--data_path", type=str, default="../dataset/sft_t2t_mini.jsonl")
+    parser.add_argument('--from_weight', default='full_sft', type=str,
+                        help="QAT 起点权重前缀（默认基于 full_sft 微调）")
+    parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1])
+    parser.add_argument("--use_wandb", action="store_true")
+    parser.add_argument("--wandb_project", type=str, default="MiniMind-QAT")
+    parser.add_argument("--use_compile", default=0, type=int, choices=[0, 1])
+
+    # ---- QAT-specific ----
+    parser.add_argument("--w_bits", type=int, default=8, help="weight 量化位宽")
+    parser.add_argument("--a_bits", type=int, default=8, help="activation 量化位宽")
+    parser.add_argument("--quant_observer_steps", type=int, default=200,
+                        help="activation observer 预热步数（仅采集 EMA，不做 fake-quant）")
+    parser.add_argument("--quant_skip", type=str, default=",".join(DEFAULT_SKIP_PATTERNS),
+                        help="名称中包含这些子串的 Linear 跳过量化（逗号分隔）"
+                             "；默认跳过 lm_head 和 MoE 路由 mlp.gate")
+    args = parser.parse_args()
+
+    # 1. dist + seed
+    local_rank = init_distributed_mode()
+    if dist.is_initialized():
+        args.device = f"cuda:{local_rank}"
+    setup_seed(42 + (dist.get_rank() if dist.is_initialized() else 0))
+
+    # 2. config + checkpoint probe
+    os.makedirs(args.save_dir, exist_ok=True)
+    lm_config = MiniMindConfig(
+        hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers,
+        use_moe=bool(args.use_moe),
+    )
+    ckp_data = lm_checkpoint(
+        lm_config, weight=args.save_weight, save_dir='../checkpoints',
+    ) if args.from_resume == 1 else None
+
+    # 3. autocast
+    device_type = "cuda" if "cuda" in args.device else "cpu"
+    dtype = torch.bfloat16 if args.dtype == "bfloat16" else torch.float16
+    autocast_ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast(dtype=dtype)
+
+    # 4. wandb
+    wandb = None
+    if args.use_wandb and is_main_process():
+        import swanlab as wandb
+        wandb_id = ckp_data.get('wandb_id') if ckp_data else None
+        resume = 'must' if wandb_id else None
+        wandb_run_name = (
+            f"MiniMind-QAT-W{args.w_bits}A{args.a_bits}-Epoch-{args.epochs}-"
+            f"BS-{args.batch_size}-LR-{args.learning_rate}"
+        )
+        wandb.init(project=args.wandb_project, name=wandb_run_name, id=wandb_id, resume=resume)
+
+    # 5. model: load fp weights -> wrap with QATLinear -> dataset/optimizer
+    if args.from_weight == 'none':
+        raise SystemExit("--from_weight=none is not supported for QAT; load a pretrained/SFT ckpt.")
+    model, tokenizer = init_model(lm_config, args.from_weight, device=args.device)
+
+    skip_patterns = tuple(s.strip() for s in args.quant_skip.split(',') if s.strip())
+    replaced = prepare_qat(
+        model, w_bits=args.w_bits, a_bits=args.a_bits,
+        skip_patterns=skip_patterns, a_observer_steps=args.quant_observer_steps,
+    )
+    Logger(f'QAT: wrapped {replaced} Linear modules '
+           f'(W{args.w_bits}A{args.a_bits}, skip={skip_patterns}, '
+           f'observer_warmup={args.quant_observer_steps} steps)')
+
+    train_ds = SFTDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
+    train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
+    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
+
+    # 6. resume
+    start_epoch, start_step = 0, 0
+    if ckp_data:
+        model.load_state_dict(ckp_data['model'])  # state dict already contains QAT buffers
+        optimizer.load_state_dict(ckp_data['optimizer'])
+        scaler.load_state_dict(ckp_data['scaler'])
+        start_epoch = ckp_data['epoch']
+        start_step = ckp_data.get('step', 0)
+
+    # 7. compile + DDP
+    if args.use_compile == 1:
+        model = torch.compile(model)
+        Logger('torch.compile enabled')
+    if dist.is_initialized():
+        model = DistributedDataParallel(model, device_ids=[local_rank])
+
+    # 8. train
+    for epoch in range(start_epoch, args.epochs):
+        train_sampler and train_sampler.set_epoch(epoch)
+        setup_seed(42 + epoch)
+        indices = torch.randperm(len(train_ds)).tolist()
+        skip = start_step if (epoch == start_epoch and start_step > 0) else 0
+        batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
+        loader = DataLoader(train_ds, batch_sampler=batch_sampler,
+                            num_workers=args.num_workers, pin_memory=True)
+        if skip > 0:
+            Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
+            train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)
+        else:
+            train_epoch(epoch, loader, len(loader), 0, wandb)
+
+    # 9. cleanup
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()

--- a/trainer/train_qat.py
+++ b/trainer/train_qat.py
@@ -20,6 +20,7 @@ from dataset.lm_dataset import SFTDataset
 from trainer.trainer_utils import (
     get_lr, Logger, is_main_process, lm_checkpoint,
     init_distributed_mode, setup_seed, init_model, SkipBatchSampler,
+    detect_gpu_peak_tflops_bf16, compute_model_flops_per_token,
 )
 
 warnings.filterwarnings('ignore')
@@ -27,10 +28,11 @@ warnings.filterwarnings('ignore')
 
 def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
     start_time = time.time()
+    last_log_time, last_log_step = start_time, start_step
     last_step = start_step
     for step, (input_ids, labels) in enumerate(loader, start=start_step + 1):
-        input_ids = input_ids.to(args.device)
-        labels = labels.to(args.device)
+        input_ids = input_ids.to(args.device, non_blocking=True)
+        labels = labels.to(args.device, non_blocking=True)
         last_step = step
         lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
         for param_group in optimizer.param_groups:
@@ -51,14 +53,26 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
             optimizer.zero_grad(set_to_none=True)
 
         if step % args.log_interval == 0 or step == iters:
-            spend_time = time.time() - start_time
+            now = time.time()
+            spend_time = now - start_time
+            window_dt = max(now - last_log_time, 1e-6)
+            window_steps = step - last_log_step
+            window_its = window_steps / window_dt
+            # MFU 报的是 dense 6P 等价吞吐；QAT 会因 fake-quant 逐 Linear 加 round/clamp/dequant
+            # 有额外内存搬运，MFU 通常比同 seq 下的 SFT 低 5-15%——这本身就是我们要观测的量。
+            tokens_window = window_steps * args.batch_size * args.max_seq_len * world_size
+            mfu = (flops_per_token * tokens_window / window_dt) / (gpu_peak_tflops * 1e12) * 100
+            last_log_time, last_log_step = now, step
             current_loss = loss.item() * args.accumulation_steps
             current_aux_loss = res.aux_loss.item() if res.aux_loss is not None else 0.0
             current_logits_loss = current_loss - current_aux_loss
             current_lr = optimizer.param_groups[-1]['lr']
             eta_min = spend_time / max(step - start_step, 1) * (iters - step) // 60
+            # observer_warmup 期内 act_fq 只统计不量化，日志上会看到一个"200 步后 loss 抖一下"的转折点。
+            qat_phase = 'observe' if step <= args.quant_observer_steps else 'fake-quant'
             Logger(
-                f'Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), '
+                f'[{time.strftime("%H:%M:%S")}] Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}), '
+                f'it/s: {window_its:.2f}, MFU: {mfu:.1f}%, phase: {qat_phase}, '
                 f'loss: {current_loss:.4f}, logits_loss: {current_logits_loss:.4f}, '
                 f'aux_loss: {current_aux_loss:.4f}, lr: {current_lr:.8f}, '
                 f'epoch_time: {eta_min:.1f}min'
@@ -67,7 +81,7 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
                 wandb.log({
                     "loss": current_loss, "logits_loss": current_logits_loss,
                     "aux_loss": current_aux_loss, "learning_rate": current_lr,
-                    "epoch_time": eta_min,
+                    "epoch_time": eta_min, "it_per_s": window_its, "mfu_pct": mfu,
                 })
 
         if (step % args.save_interval == 0 or step == iters) and is_main_process():
@@ -114,9 +128,13 @@ if __name__ == "__main__":
     parser.add_argument('--num_hidden_layers', default=8, type=int)
     parser.add_argument('--max_seq_len', default=768, type=int)
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1])
-    parser.add_argument("--data_path", type=str, default="../dataset/sft_t2t_mini.jsonl")
+    parser.add_argument("--data_path", type=str, default="../dataset/sft_t2t.jsonl")
+    parser.add_argument("--qat_subset_size", type=int, default=0,
+                        help="QAT 数据子集大小（0=用全量）；64M dry run 建议 100000，1B 正式建议 200000")
+    parser.add_argument("--gpu_peak_tflops", type=float, default=0,
+                        help="GPU bf16 理论峰值 TFLOPS，用于 MFU 计算；0=按 GPU 名自动检测")
     parser.add_argument('--from_weight', default='full_sft', type=str,
-                        help="QAT 起点权重前缀（默认基于 full_sft 微调）")
+                        help="QAT 起点权重前缀（部署走 full_sft；1.12 dry run 走 pretrain）")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1])
     parser.add_argument("--use_wandb", action="store_true")
     parser.add_argument("--wandb_project", type=str, default="MiniMind-QAT")
@@ -179,10 +197,20 @@ if __name__ == "__main__":
            f'(W{args.w_bits}A{args.a_bits}, skip={skip_patterns}, '
            f'observer_warmup={args.quant_observer_steps} steps)')
 
-    train_ds = SFTDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
+    train_ds = SFTDataset(args.data_path, tokenizer, max_length=args.max_seq_len,
+                          subset_size=args.qat_subset_size)
+    Logger(f'QAT dataset: {len(train_ds)} samples '
+           f'(subset_size={args.qat_subset_size}, seq_len={args.max_seq_len})')
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
-    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate, fused=True)
+
+    # MFU 测量准备
+    flops_per_token = compute_model_flops_per_token(model, lm_config)
+    gpu_peak_tflops = detect_gpu_peak_tflops_bf16(override=args.gpu_peak_tflops)
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    Logger(f'[MFU] params_flops/token={flops_per_token/1e9:.3f} GFLOPS, '
+           f'GPU peak={gpu_peak_tflops:.0f} TFLOPS bf16, world_size={world_size}')
 
     # 6. resume
     start_epoch, start_step = 0, 0
@@ -208,7 +236,8 @@ if __name__ == "__main__":
         skip = start_step if (epoch == start_epoch and start_step > 0) else 0
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
         loader = DataLoader(train_ds, batch_sampler=batch_sampler,
-                            num_workers=args.num_workers, pin_memory=True)
+                            num_workers=args.num_workers, pin_memory=True,
+                            persistent_workers=args.num_workers > 0)
         if skip > 0:
             Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
             train_epoch(epoch, loader, len(loader) + skip, start_step, wandb)

--- a/trainer/train_qat.py
+++ b/trainer/train_qat.py
@@ -88,20 +88,25 @@ def train_epoch(epoch, loader, iters, start_step=0, wandb=None):
                     "epoch_time": eta_min, "it_per_s": window_its, "mfu_pct": mfu,
                 })
 
-        if (step % args.save_interval == 0 or step == iters) and is_main_process():
-            model.eval()
-            moe_suffix = '_moe' if lm_config.use_moe else ''
-            ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
-            raw_model = model.module if isinstance(model, DistributedDataParallel) else model
-            raw_model = getattr(raw_model, '_orig_mod', raw_model)
-            state_dict = raw_model.state_dict()
-            torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp)
-            lm_checkpoint(
-                lm_config, weight=args.save_weight, model=model, optimizer=optimizer,
-                epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints', scaler=scaler,
-            )
-            model.train()
-            del state_dict
+        if step % args.save_interval == 0 or step == iters:
+            if is_main_process():
+                model.eval()
+                moe_suffix = '_moe' if lm_config.use_moe else ''
+                ckp = f'{args.save_dir}/{args.save_weight}_{lm_config.hidden_size}{moe_suffix}.pth'
+                raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+                raw_model = getattr(raw_model, '_orig_mod', raw_model)
+                state_dict = raw_model.state_dict()
+                ckp_tmp = ckp + '.tmp'
+                torch.save({k: v.half().cpu() for k, v in state_dict.items()}, ckp_tmp)
+                os.replace(ckp_tmp, ckp)
+                lm_checkpoint(
+                    lm_config, weight=args.save_weight, model=model, optimizer=optimizer,
+                    epoch=epoch, step=step, wandb=wandb, save_dir='../checkpoints', scaler=scaler,
+                )
+                model.train()
+                del state_dict
+            if dist.is_initialized():
+                dist.barrier()
 
         del input_ids, labels, res, loss
 

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -51,14 +51,18 @@ def init_distributed_mode():
     return local_rank
 
 
-def setup_seed(seed: int):
+def setup_seed(seed: int, deterministic: bool = False):
+    # cudnn 决定性 + 禁 benchmark 是预训练吞吐杀手（A100 上 ~3-5x 慢）。
+    # 默认走 benchmark=True 让 cudnn 选最快 kernel；要严格复现传 deterministic=True。
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.deterministic = deterministic
+    torch.backends.cudnn.benchmark = not deterministic
+    # A100 TF32 矩阵乘加速（autocast bf16 路径之外的 fp32 matmul 才生效，但无副作用）
+    torch.set_float32_matmul_precision('high')
 
 def lm_checkpoint(lm_config, weight='full_sft', model=None, optimizer=None, epoch=0, step=0, wandb=None, save_dir='../checkpoints', **kwargs):
     os.makedirs(save_dir, exist_ok=True)

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -41,6 +41,53 @@ def get_lr(current_step, total_steps, lr):
     return lr*(0.1 + 0.45*(1 + math.cos(math.pi * current_step / total_steps)))
 
 
+# A100/H100/3090 等常见卡的 bf16 理论峰值 TFLOPS。MoE 等价 FLOPs 是 active params 不是 total，
+# active params 算出来的 MFU 才有意义；MoE 的 active 比例由 num_experts_per_tok / num_experts 决定。
+_GPU_PEAK_BF16_TFLOPS = {
+    'A100': 312, 'A100-SXM4-80GB': 312, 'A100-SXM4-40GB': 312, 'A100-PCIE-80GB': 312, 'A100-PCIE-40GB': 312,
+    'H100': 989, 'H100-SXM5-80GB': 989, 'H100-PCIE-80GB': 756, 'H100 80GB HBM3': 989,
+    'H200': 989,
+    'RTX 3090': 71, 'GeForce RTX 3090': 71, 'RTX 3090 Ti': 80,
+    'RTX 4090': 165, 'GeForce RTX 4090': 165,
+    'V100': 125, 'V100-SXM2-32GB': 125,
+    'L40': 181, 'L40S': 362,
+}
+
+
+def detect_gpu_peak_tflops_bf16(device_index: int = 0, override: float = None) -> float:
+    """Look up the bf16 TensorCore peak for the current GPU; fall back to A100 (312)."""
+    if override is not None and override > 0:
+        return float(override)
+    if not torch.cuda.is_available():
+        return 312.0
+    name = torch.cuda.get_device_name(device_index)
+    for key, peak in _GPU_PEAK_BF16_TFLOPS.items():
+        if key in name:
+            return float(peak)
+    Logger(f'[MFU] Unknown GPU "{name}", falling back to A100 (312 TFLOPS). Pass --gpu_peak_tflops to override.')
+    return 312.0
+
+
+def compute_model_flops_per_token(model, config=None) -> float:
+    """Compute the "model FLOPs" per training token (forward + backward).
+
+    Standard approximation for dense transformers: 6 × P, where P is the total
+    trainable params count. For MoE we use active params = base + experts_per_tok × per_expert.
+    """
+    raw = model.module if isinstance(model, DistributedDataParallel) else model
+    raw = getattr(raw, '_orig_mod', raw)
+    total = sum(p.numel() for p in raw.parameters())
+    if config is not None and getattr(config, 'use_moe', False):
+        n_routed = getattr(config, 'num_experts', 0)
+        n_active = getattr(config, 'num_experts_per_tok', 1)
+        if n_routed > 0:
+            expert = sum(p.numel() for n, p in raw.named_parameters() if 'mlp.experts.0.' in n)
+            base = total - expert * n_routed
+            active = base + expert * n_active
+            return 6.0 * active
+    return 6.0 * total
+
+
 def init_distributed_mode():
     if int(os.environ.get("RANK", -1)) == -1:
         return 0  # 非DDP模式

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -37,8 +37,19 @@ def Logger(content):
         print(content)
 
 
-def get_lr(current_step, total_steps, lr):
-    return lr*(0.1 + 0.45*(1 + math.cos(math.pi * current_step / total_steps)))
+def get_lr(current_step, total_steps, lr, warmup_steps=0):
+    """
+    Linear warmup + cosine decay。
+    - warmup_steps=0（默认）: 纯 cosine，向后兼容
+    - warmup_steps>0: 前 warmup_steps 步从 0.1*lr 线性升到 lr，之后 cosine 到 0.1*lr
+
+    1B from-scratch 必须 warmup（无 warmup 时前 500 步 loss 发散概率 >50%，
+    因为随机初始化的权重在 full lr 下第一步梯度过大打乱结构）。
+    """
+    if warmup_steps > 0 and current_step < warmup_steps:
+        return lr * (0.1 + 0.9 * current_step / warmup_steps)
+    progress = (current_step - warmup_steps) / max(total_steps - warmup_steps, 1)
+    return lr * (0.1 + 0.45 * (1 + math.cos(math.pi * progress)))
 
 
 # A100/H100/3090 等常见卡的 bf16 理论峰值 TFLOPS。MoE 等价 FLOPs 是 active params 不是 total，
@@ -115,6 +126,14 @@ def setup_seed(seed: int, deterministic: bool = False):
     torch.set_float32_matmul_precision('high')
 
 def lm_checkpoint(lm_config, weight='full_sft', model=None, optimizer=None, epoch=0, step=0, wandb=None, save_dir='../checkpoints', **kwargs):
+    """
+    save mode (model != None): 只在 rank-0 写盘，非 main rank 早返回。
+    load mode (model == None): 所有 rank 读同一份 ckpt，无冲突。
+    调用方在 save 后应加 dist.barrier()，让非-0 rank 等待 rank-0 写完再进入下一 step。
+    """
+    # DDP 保护：save 必须由单一 rank 执行；否则 4 rank 同写一个 file 会 corrupt。
+    if model is not None and not is_main_process():
+        return None
     os.makedirs(save_dir, exist_ok=True)
     moe_path = '_moe' if lm_config.use_moe else ''
     ckp_path = f'{save_dir}/{weight}_{lm_config.hidden_size}{moe_path}.pth'

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -45,6 +45,9 @@ def get_lr(current_step, total_steps, lr):
 # active params 算出来的 MFU 才有意义；MoE 的 active 比例由 num_experts_per_tok / num_experts 决定。
 _GPU_PEAK_BF16_TFLOPS = {
     'A100': 312, 'A100-SXM4-80GB': 312, 'A100-SXM4-40GB': 312, 'A100-PCIE-80GB': 312, 'A100-PCIE-40GB': 312,
+    'PG509-210': 312, 'PG509-200': 312,  # NVIDIA marketing name for A100 80/40GB on some devservers
+    'PG506-243': 989,  # H100 SXM5 devserver naming
+    'HGX': 989, 'HGX H100': 989,
     'H100': 989, 'H100-SXM5-80GB': 989, 'H100-PCIE-80GB': 756, 'H100 80GB HBM3': 989,
     'H200': 989,
     'RTX 3090': 71, 'GeForce RTX 3090': 71, 'RTX 3090 Ti': 80,


### PR DESCRIPTION
 1. cudnn.benchmark=True
  cuDNN 对每个 conv/matmul 有多套实现（Winograd、隐式 GEMM、FFT、各种 tile/split-K 策略）。benchmark=True 在第一次遇到某个 (input_shape, dtype, stride) 时把所有候选 kernel 都跑一遍计时，把最快那个缓存下来。LLM 训练 shape 是完全固定（batch×seq×hidden 每步一样），所以"额外开销付一次、收益吃满整个 epoch"。

反过来 deterministic=True 会排除掉最快的那批 kernel——很多高性能 kernel 用 atomicAdd 做规约，结果浮点累加顺序不确定。强制确定性 → cuDNN 只能选慢的备选。两个加在一起：A100 上 attention/projection 经常被压到 30-50% 的应有性能。

  2. torch.compile
  - 算子融合：SwiGLU 的 silu(gate_proj(x)) * up_proj(x) 在 eager 模式是 3 个独立 kernel + 中间张量来回 HBM；编译后融成 1 个 Triton kernel，中间结果留在寄存器/共享内存，HBM 带宽省一大截
  - 干掉 Python dispatch 开销：eager 模式每个 op 都过 Python → C++ dispatcher → 找 backend → launch kernel，对小算子（RMSNorm、residual add、reshape）Python 开销甚至比 GPU 实际算还久。编译后整张图一次 launch
  - Triton 自动生成：对没有 hand-tuned cuBLAS kernel 的形状（比如 RMSNorm + 后接 matmul 这种组合），生成定制 Triton 比通用 cuBLAS 更快

  3. set_float32_matmul_precision('high')
  bf16 autocast 路径里大多数 matmul 已经是 bf16 TC，但仍有 fp32 路径走 CUDA core：optimizer step、RMSNorm、RoPE 复频系数计算等。'high' 让这些 fp32 matmul 走 TF32 TensorCore，A100 上理论 ~8x（实际 2x）。

  4. RoPE 的 sync 修掉
原代码 if self.freqs_cos[0,0] == 0:：== 返回 GPU 上的 0-d 张量，用在 Python if 里会强制 .item()——这是个完整 sync：等当前所有未完成 GPU kernel 结束 → 拷贝 1 个 scalar 到 CPU → Python 才继续。
正常情况 PyTorch 是 async 的：Python 提前 launch 几十个 kernel，GPU 排队执行，CPU launch 速度 > GPU 执行速度时永远不空。每个 forward 一次 sync 直接把队列清空，下一个 kernel 又得从 0 开始排——pipeline 完全断了。8 层模型每 step 至少 ~16-30 个 forward/backward 入队机会，断掉的代价是几十毫秒。