### PR TITLE
[fix] keep DPO preference-pair think formatting aligned

### DIFF
--- a/dataset/lm_dataset.py
+++ b/dataset/lm_dataset.py
@@ -28,10 +28,13 @@ def pre_processing_chat(conversations, add_system_ratio=0.2):
             return [{'role': 'system', 'content': random.choice(SYSTEM_PROMPTS)}] + conversations
     return conversations
 
-def post_processing_chat(prompt_content, empty_think_ratio=0.2):
+def post_processing_chat(prompt_content, empty_think_ratio=0.2, remove_empty_think=None):
     # 以80%概率移除空思考标签
-    if '<think>\n\n</think>\n\n' in prompt_content and random.random() > empty_think_ratio:
-        prompt_content = prompt_content.replace('<think>\n\n</think>\n\n', '')
+    if '<think>\n\n</think>\n\n' in prompt_content:
+        if remove_empty_think is None:
+            remove_empty_think = random.random() > empty_think_ratio
+        if remove_empty_think:
+            prompt_content = prompt_content.replace('<think>\n\n</think>\n\n', '')
     return prompt_content
 
 class PretrainDataset(Dataset):
@@ -139,12 +142,13 @@ class DPODataset(Dataset):
         chosen_prompt = self.tokenizer.apply_chat_template(
             chosen, tokenize=False, add_generation_prompt=False
         )
-        chosen_prompt = post_processing_chat(chosen_prompt)
 
         rejected_prompt = self.tokenizer.apply_chat_template(
             rejected, tokenize=False, add_generation_prompt=False
         )
-        rejected_prompt = post_processing_chat(rejected_prompt)
+        remove_empty_think = random.random() > 0.2
+        chosen_prompt = post_processing_chat(chosen_prompt, remove_empty_think=remove_empty_think)
+        rejected_prompt = post_processing_chat(rejected_prompt, remove_empty_think=remove_empty_think)
         chosen_encoding = self.tokenizer(
             chosen_prompt, truncation=True, max_length=self.max_length, padding='max_length'
         )


### PR DESCRIPTION
## What

- reuse one empty-`<think>` removal decision for each DPO preference pair
- keep the existing SFT sampling behavior unchanged

## Why

`DPODataset` currently post-processes the chosen and rejected sequences independently. With the current 80% removal / 20% retention mix, the pair receives different empty-`<think>` formatting 32% of the time even though both responses start from the same template format. This adds unrelated formatting noise to the preference comparison.

The official `dpo.jsonl` currently contains 17,166 pairs; all have the same user-side prefix and neither response provides `reasoning_content`, so both rendered responses initially contain the empty tag.

## Validation

- exercised both branches with the repository tokenizer: chosen and rejected both retain the tag when sampled to keep, and both remove it when sampled to remove
- verified one random draw per preference pair
- verified prompts without an empty tag preserve the prior no-draw behavior
- `python -m compileall -q dataset model trainer scripts eval_llm.py`
- `git diff --check`