### PR TITLE
Expose num_experts / num_experts_per_tok / seed on the trainer CLIs

### DIFF
--- a/eval_llm.py
+++ b/eval_llm.py
@@ -16,6 +16,8 @@ def init_model(args):
             hidden_size=args.hidden_size,
             num_hidden_layers=args.num_hidden_layers,
             use_moe=bool(args.use_moe),
+            num_experts=args.num_experts,
+            num_experts_per_tok=args.num_experts_per_tok,
             inference_rope_scaling=args.inference_rope_scaling
         ))
         moe_suffix = '_moe' if args.use_moe else ''
@@ -38,6 +40,8 @@ def main():
     parser.add_argument('--hidden_size', default=768, type=int, help="隐藏层维度")
     parser.add_argument('--num_hidden_layers', default=8, type=int, help="隐藏层数量")
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
+    parser.add_argument('--num_experts', default=4, type=int, help="MoE专家数量（仅use_moe=1时生效，需与训练时一致）")
+    parser.add_argument('--num_experts_per_tok', default=1, type=int, help="每个token路由到的专家数（仅use_moe=1时生效，需与训练时一致）")
     parser.add_argument('--inference_rope_scaling', default=False, action='store_true', help="启用RoPE位置编码外推（4倍，仅解决位置编码问题）")
     parser.add_argument('--max_new_tokens', default=8192, type=int, help="最大生成长度（注意：并非模型实际长文本能力）")
     parser.add_argument('--temperature', default=0.85, type=float, help="生成温度，控制随机性（0-1，越大越随机）")

--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -99,6 +99,8 @@ if __name__ == "__main__":
     parser.add_argument('--num_hidden_layers', default=8, type=int, help="隐藏层数量")
     parser.add_argument('--max_seq_len', default=768, type=int, help="训练的最大截断长度（中文1token≈1.5~1.7字符）")
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
+    parser.add_argument('--num_experts', default=4, type=int, help="MoE专家数量（仅use_moe=1时生效）")
+    parser.add_argument('--num_experts_per_tok', default=1, type=int, help="每个token路由到的专家数（仅use_moe=1时生效）")
     parser.add_argument("--data_path", type=str, default="../dataset/sft_t2t_mini.jsonl", help="训练数据路径")
     parser.add_argument('--from_weight', default='pretrain', type=str, help="基于哪个权重训练，为none则不基于任何权重训练")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
@@ -114,7 +116,8 @@ if __name__ == "__main__":
     
     # ========== 2. 配置目录、模型参数、检查ckp ==========
     os.makedirs(args.save_dir, exist_ok=True)
-    lm_config = MiniMindConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe))
+    lm_config = MiniMindConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe),
+                               num_experts=args.num_experts, num_experts_per_tok=args.num_experts_per_tok)
     ckp_data = lm_checkpoint(lm_config, weight=args.save_weight, save_dir='../checkpoints') if args.from_resume==1 else None
     
     # ========== 3. 设置混合精度 ==========

--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
     parser.add_argument('--num_experts', default=4, type=int, help="MoE专家数量（仅use_moe=1时生效）")
     parser.add_argument('--num_experts_per_tok', default=1, type=int, help="每个token路由到的专家数（仅use_moe=1时生效）")
+    parser.add_argument('--seed', default=42, type=int, help="随机种子（DDP下每个rank为seed+rank，每轮为seed+epoch）")
     parser.add_argument("--data_path", type=str, default="../dataset/sft_t2t_mini.jsonl", help="训练数据路径")
     parser.add_argument('--from_weight', default='pretrain', type=str, help="基于哪个权重训练，为none则不基于任何权重训练")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
@@ -112,7 +113,7 @@ if __name__ == "__main__":
     # ========== 1. 初始化环境和随机种子 ==========
     local_rank = init_distributed_mode()
     if dist.is_initialized(): args.device = f"cuda:{local_rank}"
-    setup_seed(42 + (dist.get_rank() if dist.is_initialized() else 0))
+    setup_seed(args.seed + (dist.get_rank() if dist.is_initialized() else 0))
     
     # ========== 2. 配置目录、模型参数、检查ckp ==========
     os.makedirs(args.save_dir, exist_ok=True)
@@ -160,7 +161,7 @@ if __name__ == "__main__":
     # ========== 8. 开始训练 ==========
     for epoch in range(start_epoch, args.epochs):
         train_sampler and train_sampler.set_epoch(epoch)
-        setup_seed(42 + epoch); indices = torch.randperm(len(train_ds)).tolist()
+        setup_seed(args.seed + epoch); indices = torch.randperm(len(train_ds)).tolist()
         skip = start_step if (epoch == start_epoch and start_step > 0) else 0
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
         loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers, pin_memory=True)

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -98,6 +98,8 @@ if __name__ == "__main__":
     parser.add_argument('--num_hidden_layers', default=8, type=int, help="隐藏层数量")
     parser.add_argument('--max_seq_len', default=340, type=int, help="训练的最大截断长度（中文1token≈1.5~1.7字符）")
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
+    parser.add_argument('--num_experts', default=4, type=int, help="MoE专家数量（仅use_moe=1时生效）")
+    parser.add_argument('--num_experts_per_tok', default=1, type=int, help="每个token路由到的专家数（仅use_moe=1时生效）")
     parser.add_argument("--data_path", type=str, default="../dataset/pretrain_t2t_mini.jsonl", help="预训练数据路径")
     parser.add_argument('--from_weight', default='none', type=str, help="基于哪个权重训练，为none则从头开始")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
@@ -113,7 +115,8 @@ if __name__ == "__main__":
     
     # ========== 2. 配置目录、模型参数、检查ckp ==========
     os.makedirs(args.save_dir, exist_ok=True)
-    lm_config = MiniMindConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe))
+    lm_config = MiniMindConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe),
+                               num_experts=args.num_experts, num_experts_per_tok=args.num_experts_per_tok)
     ckp_data = lm_checkpoint(lm_config, weight=args.save_weight, save_dir='../checkpoints') if args.from_resume==1 else None
     
     # ========== 3. 设置混合精度 ==========

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
     parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help="是否使用MoE架构（0=否，1=是）")
     parser.add_argument('--num_experts', default=4, type=int, help="MoE专家数量（仅use_moe=1时生效）")
     parser.add_argument('--num_experts_per_tok', default=1, type=int, help="每个token路由到的专家数（仅use_moe=1时生效）")
+    parser.add_argument('--seed', default=42, type=int, help="随机种子（DDP下每个rank为seed+rank，每轮为seed+epoch）")
     parser.add_argument("--data_path", type=str, default="../dataset/pretrain_t2t_mini.jsonl", help="预训练数据路径")
     parser.add_argument('--from_weight', default='none', type=str, help="基于哪个权重训练，为none则从头开始")
     parser.add_argument('--from_resume', default=0, type=int, choices=[0, 1], help="是否自动检测&续训（0=否，1=是）")
@@ -111,7 +112,7 @@ if __name__ == "__main__":
     # ========== 1. 初始化环境和随机种子 ==========
     local_rank = init_distributed_mode()
     if dist.is_initialized(): args.device = f"cuda:{local_rank}"
-    setup_seed(42 + (dist.get_rank() if dist.is_initialized() else 0))
+    setup_seed(args.seed + (dist.get_rank() if dist.is_initialized() else 0))
     
     # ========== 2. 配置目录、模型参数、检查ckp ==========
     os.makedirs(args.save_dir, exist_ok=True)
@@ -159,7 +160,7 @@ if __name__ == "__main__":
     # ========== 8. 开始训练 ==========
     for epoch in range(start_epoch, args.epochs):
         train_sampler and train_sampler.set_epoch(epoch)
-        setup_seed(42 + epoch); indices = torch.randperm(len(train_ds)).tolist()
+        setup_seed(args.seed + epoch); indices = torch.randperm(len(train_ds)).tolist()
         skip = start_step if (epoch == start_epoch and start_step > 0) else 0
         batch_sampler = SkipBatchSampler(train_sampler or indices, args.batch_size, skip)
         loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers, pin_memory=True)


### PR DESCRIPTION
> **In one sentence:** you can now choose how many MoE experts to use, and which random seed to train with, from the command line — instead of editing `model_minimind.py`.
>
> Nothing changes unless you pass the new flags: every default is the value that is already hardcoded today (`num_experts=4`, `num_experts_per_tok=1`, `seed=42`).
>
> **一句话：** 现在可以直接在命令行里指定 MoE 专家数量和训练随机种子，不必再去改 `model_minimind.py`。不传新参数时行为完全不变——所有默认值都等于现在写死在代码里的值（`num_experts=4`、`num_experts_per_tok=1`、`seed=42`）。

---

Changing the number of experts currently requires editing `model/model_minimind.py` — every entry point builds `MiniMindConfig(...)` inline from argparse and passes only `hidden_size`, `num_hidden_layers` and `use_moe`, so `num_experts` and `num_experts_per_tok` are reachable only by editing the model file.

This adds both as CLI flags on the three non-RL entry points:

- `trainer/train_pretrain.py`
- `trainer/train_full_sft.py`
- `eval_llm.py`

**Defaults match `MiniMindConfig` exactly (`num_experts=4`, `num_experts_per_tok=1`), so behaviour is unchanged unless the flags are passed.** I checked this with an assertion against the config's own defaults rather than by eye, since a mismatch here would silently change what `--use_moe 1` trains.

```
--num_experts NUM_EXPERTS
                      MoE专家数量（仅use_moe=1时生效）
--num_experts_per_tok NUM_EXPERTS_PER_TOK
                      每个token路由到的专家数（仅use_moe=1时生效）
```

The README discusses the trade-off at `4 experts / top-1` and notes that cost rises as experts increase; with this change a reader can actually try 2, 8 or 16 and see that for themselves, which is hard to do today.

Deliberately out of scope:

- The RL and agent trainers (`train_dpo`, `train_grpo`, `train_ppo`, `train_lora`, `train_agent`, …) are untouched.
- Checkpoint filenames are unchanged. `{save_weight}_{hidden_size}{moe_suffix}.pth` does not encode the expert count, so two runs with different `--num_experts` will collide — but it does not encode `num_hidden_layers` either, so this is pre-existing behaviour rather than something this PR introduces. I left it alone to keep the diff to one concern; happy to address it separately if you want the filename to carry more of the config.


## Also: `--seed`

The trainers already seed — `setup_seed(42 + rank)` at startup and `setup_seed(42 + epoch)` per epoch (`trainer/train_pretrain.py:115,163`) — but **42 is a literal in both places and is not reachable from the CLI**, so running the same config under a different seed means editing the source.

This adds `--seed`, **default 42**, substituted at both call sites. Behaviour is unchanged unless the flag is passed.

Verified: same seed reproduces identical initial weights, different seeds do not (`torch.equal` over all parameters), and the default value still matches the literal it replaced.

Why it is worth having: any claim of the form "config A scores N points above config B" is only meaningful against run-to-run variation, and at the moment a user cannot produce that variation without patching the repo. This makes seed sweeps possible without a fork.

3 files, +18/−6.

---

目前要修改专家数量，只能去编辑 `model/model_minimind.py`：各个入口都是在 argparse 之后内联构造 `MiniMindConfig(...)`，且只传了 `hidden_size`、`num_hidden_layers` 和 `use_moe`，因此 `num_experts` 与 `num_experts_per_tok` 只能通过改模型文件来调整。

本 PR 把这两个参数加到三个非 RL 入口的命令行上：`trainer/train_pretrain.py`、`trainer/train_full_sft.py`、`eval_llm.py`。

**默认值与 `MiniMindConfig` 完全一致（`num_experts=4`、`num_experts_per_tok=1`），不传这两个参数时行为不变。** 我用断言对照了配置本身的默认值，而不是靠肉眼核对——这里一旦对不上，会悄悄改变 `--use_moe 1` 实际训练的模型。

README 里讨论了 `4 experts / top-1` 的取舍，也提到专家数增加后开销上升；有了这个改动，读者可以自己跑 2 / 8 / 16 来验证，而目前这件事并不容易做到。

有意不在范围内的部分：

- RL 与 agent 相关的 trainer（`train_dpo`、`train_grpo`、`train_ppo`、`train_lora`、`train_agent` 等）均未改动。
- checkpoint 文件名未改。`{save_weight}_{hidden_size}{moe_suffix}.pth` 不包含专家数，所以用不同 `--num_experts` 跑两次会互相覆盖；但它同样不包含 `num_hidden_layers`，因此这属于既有行为，并非本 PR 引入。为了让 diff 只做一件事，我没有动它；如果您希望文件名承载更多配置信息，我可以另开 PR 处理。


## 另外：`--seed`

trainer 本来就设了种子——启动时 `setup_seed(42 + rank)`、每轮 `setup_seed(42 + epoch)`（`trainer/train_pretrain.py:115,163`）——但**两处的 42 都是字面量，命令行拿不到**，所以想换个种子跑同一份配置只能改源码。

本 PR 新增 `--seed`，**默认 42**，在这两处替换字面量。不传该参数时行为完全不变。

已验证：相同种子得到逐位相同的初始权重，不同种子则不同（对全部参数做 `torch.equal`），且默认值与被替换的字面量一致。

为什么值得加：任何"配置 A 比配置 B 高 N 分"的结论，都只有相对于run-to-run 波动才有意义；而目前用户不修改仓库就无法产生这种波动。这个改动让多种子实验不必先 fork。

3 个文件，+18/−6。

