### PR TITLE
MoE dispatch: one host sync per layer instead of 3×num_experts

### DIFF
--- a/model/model_minimind.py
+++ b/model/model_minimind.py
@@ -159,15 +159,30 @@ class MOEFeedForward(nn.Module):
         scores = F.softmax(self.gate(x_flat), dim=-1)
         topk_weight, topk_idx = torch.topk(scores, k=self.config.num_experts_per_tok, dim=-1, sorted=False)
         if self.config.norm_topk_prob: topk_weight = topk_weight / (topk_weight.sum(dim=-1, keepdim=True) + 1e-20)
-        y = torch.zeros_like(x_flat)
+        # 先把 token 按专家排成连续段，每个专家取一段连续切片。
+        # 直觉上更自然的写法是每个专家做一次 mask：`if mask.any(): x_flat[mask.any(-1).nonzero()]`，
+        # 但 mask.any() 的取值、nonzero() 的输出长度、布尔索引的结果长度都必须先回到主机才知道，
+        # 于是每个专家都要 3 次 device→host 同步（每层 3E 次，默认配置下每次前向 96 次）。
+        # 同步会清空 CUDA 流：GPU 停下来等 CPU 读值再重新下发，而这些开销全花在路由的簿记上。
+        # 排序之后每段的边界一次就能算完，整层只剩 ends.tolist() 一次同步，且与专家数无关。
+        # stable=True 保证段内 token 仍按原顺序，因此结果与逐专家 mask 的写法逐位相同
+        #（掩码版本作为参考实现保留在 scripts/test_moe_sorted.py，每次跑测试都会断言两者一致）。
+        e, k = self.config.num_experts, self.config.num_experts_per_tok
+        flat = topk_idx.reshape(-1)
+        idx_sorted, order = torch.sort(flat, stable=True)
+        ends = torch.searchsorted(idx_sorted, torch.arange(e, device=x_flat.device, dtype=flat.dtype), right=True)
+        token_idx = order.div(k, rounding_mode='floor')  # 每个槽位对应的原 token
+        x_sorted = x_flat.index_select(0, token_idx)
+        weight = topk_weight.reshape(-1).index_select(0, order).unsqueeze(1)
+        bounds = [0] + ends.tolist()  # 整层唯一一次 device→host 同步
+        y, outs = torch.zeros_like(x_flat), []
         for i, expert in enumerate(self.experts):
-            mask = (topk_idx == i)
-            if mask.any():
-                token_idx = mask.any(dim=-1).nonzero().flatten()
-                weight = topk_weight[mask].view(-1, 1)
-                y.index_add_(0, token_idx, (expert(x_flat[token_idx]) * weight).to(y.dtype))
+            lo, hi = bounds[i], bounds[i + 1]
+            if hi > lo:
+                outs.append(expert(x_sorted[lo:hi]))  # 主机侧的 python int 比较，不会触发同步
             elif self.training:
                 y[0, 0] += 0 * sum(p.sum() for p in expert.parameters())
+        if outs: y.index_add_(0, token_idx, (torch.cat(outs) * weight).to(y.dtype))
         if self.training and self.config.router_aux_loss_coef > 0:
             load = F.one_hot(topk_idx, self.config.num_experts).float().mean(0)
             self.aux_loss = (load * scores.mean(0)).sum() * self.config.num_experts * self.config.router_aux_loss_coef

--- a/scripts/bench_moe.py
+++ b/scripts/bench_moe.py
@@ -1,0 +1,115 @@
+"""MoE 分发的性能基准 / MoE dispatch benchmark. 自包含，不引入任何新依赖。
+
+  --mode sync-probe   测本机一次 device→host 同步的往返开销
+  --mode layer        单个 MoE 层：当前实现 vs 改动前的掩码写法
+
+为什么要先测同步开销：掩码写法每层要做 3E 次主机往返，一次往返的代价由主机 CPU/PCIe
+延迟决定，而不是 GPU。我实测过从裸机主机的几微秒到 WSL2 笔记本的约 120 微秒，
+所以同一份基准在同型号 GPU、不同主机上可以相差 2-3 倍。先看自己机器的往返开销，
+再看下面的加速比，才知道该期待哪一端。
+
+计时协议：≥10 次预热，计时区间前后 torch.cuda.synchronize()，取中位数并报告 min/max。
+"""
+import argparse
+import os
+import statistics
+import sys
+import time
+
+import torch
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from model.model_minimind import MiniMindConfig, MOEFeedForward
+from scripts.test_moe_sorted import reference_masked_forward
+
+
+def timed(fn, warmup=10, reps=20):
+    for _ in range(warmup): fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(reps):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        samples.append(time.perf_counter() - t0)
+    return {'median': statistics.median(samples), 'min': min(samples), 'max': max(samples)}
+
+
+def mode_sync_probe(args):
+    flag = torch.zeros(1, dtype=torch.bool, device='cuda')
+    x = torch.randn(1024, 1024, device='cuda')
+
+    def probe(fn, n):
+        for _ in range(20): fn()
+        torch.cuda.synchronize()
+        s = []
+        for _ in range(args.reps):
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(n): fn()
+            torch.cuda.synchronize()
+            s.append((time.perf_counter() - t0) / n)
+        return statistics.median(s)
+
+    launch = probe(lambda: x.add_(0.0), 200)
+    rt = probe(lambda: flag.any().item(), 100)
+    print(f'  kernel launch (无同步) : {launch * 1e6:8.2f} us')
+    print(f'  device->host 往返      : {rt * 1e6:8.2f} us   <- 掩码写法每层要做 3E 次')
+    e, l = args.experts[0], args.num_hidden_layers
+    print(f'\n  按 3 x {e} experts x {l} layers 估算，仅路由簿记的主机开销下限约 '
+          f'{3 * e * l * rt * 1e3:.2f} ms/前向')
+
+
+def mode_layer(args):
+    print(f'{"E":>4}  {"masked (改动前)":>18}  {"sorted (当前)":>18}  {"加速":>7}  {"峰值显存":>16}')
+    for e in args.experts:
+        torch.manual_seed(0)
+        mod = MOEFeedForward(MiniMindConfig(
+            hidden_size=args.hidden_size, use_moe=True, num_experts=e,
+            num_experts_per_tok=args.top_k, moe_intermediate_size=args.hidden_size * 2)).cuda().train()
+        x = torch.randn(args.batch_size, args.seq_len, args.hidden_size, device='cuda')
+
+        def run(fn):
+            def step():
+                with torch.autocast('cuda', dtype=torch.bfloat16):
+                    fn(x).sum().backward()
+                mod.zero_grad(set_to_none=True)
+            torch.cuda.reset_peak_memory_stats()
+            r = timed(step, args.warmup, args.reps)
+            r['peak'] = torch.cuda.max_memory_allocated() / 1e6
+            return r
+
+        try:
+            a = run(lambda t: reference_masked_forward(mod, t))
+            b = run(mod)
+        except torch.cuda.OutOfMemoryError:
+            print(f'{e:>4}  OOM'); continue
+        print(f'{e:>4}  {a["median"] * 1e3:8.2f} ms [{a["min"] * 1e3:6.2f},{a["max"] * 1e3:6.2f}]  '
+              f'{b["median"] * 1e3:8.2f} ms [{b["min"] * 1e3:6.2f},{b["max"] * 1e3:6.2f}]  '
+              f'{a["median"] / b["median"]:6.2f}x  {a["peak"]:7.0f} -> {b["peak"]:5.0f} MB')
+        del mod; torch.cuda.empty_cache()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--mode', default='sync-probe', choices=['sync-probe', 'layer'])
+    p.add_argument('--hidden_size', default=768, type=int)
+    p.add_argument('--num_hidden_layers', default=8, type=int)
+    p.add_argument('--batch_size', default=8, type=int)
+    p.add_argument('--seq_len', default=512, type=int)
+    p.add_argument('--top_k', default=1, type=int)
+    p.add_argument('--experts', default='2,4,8,16', type=lambda s: [int(x) for x in s.split(',')])
+    p.add_argument('--warmup', default=10, type=int)
+    p.add_argument('--reps', default=20, type=int)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        print('本脚本需要 CUDA。/ This benchmark requires CUDA.'); sys.exit(1)
+    print(f'torch {torch.__version__}  {torch.cuda.get_device_name(0)}  '
+          f'sm_{"".join(map(str, torch.cuda.get_device_capability(0)))}\n')
+    {'sync-probe': mode_sync_probe, 'layer': mode_layer}[args.mode](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test_moe_sorted.py
+++ b/scripts/test_moe_sorted.py
@@ -1,0 +1,186 @@
+"""MoE 排序分发的正确性测试 / correctness tests for the sorted MoE dispatch.
+
+本仓库没有 pytest / CI，所以这里不引入任何测试框架，直接 `python scripts/test_moe_sorted.py`
+运行，失败返回非零。
+
+reference_masked_forward 是改动之前逐专家做 mask 的写法，保留在这里作为参考实现：
+它每次运行都会被执行，并断言与当前实现逐位相同，因此既能当作对照读，也不会随代码腐烂。
+"""
+import os
+import sys
+import traceback
+import warnings
+
+import torch
+import torch.nn.functional as F
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from model.model_minimind import MiniMindConfig, MOEFeedForward
+
+
+class Skip(Exception): pass
+
+
+# ============================== 参考实现 / reference ==============================
+
+def reference_masked_forward(mod, x):
+    """改动前的逐专家掩码写法，逐位对照用。
+
+    每个专家都要 3 次 device→host 同步：mask.any() 的取值、nonzero() 的输出长度、
+    布尔索引的结果长度，全都得先回到主机才知道。
+    """
+    batch_size, seq_len, hidden_dim = x.shape
+    x_flat = x.view(-1, hidden_dim)
+    scores = F.softmax(mod.gate(x_flat), dim=-1)
+    topk_weight, topk_idx = torch.topk(scores, k=mod.config.num_experts_per_tok, dim=-1, sorted=False)
+    if mod.config.norm_topk_prob: topk_weight = topk_weight / (topk_weight.sum(dim=-1, keepdim=True) + 1e-20)
+    y = torch.zeros_like(x_flat)
+    for i, expert in enumerate(mod.experts):
+        mask = (topk_idx == i)
+        if mask.any():
+            token_idx = mask.any(dim=-1).nonzero().flatten()
+            weight = topk_weight[mask].view(-1, 1)
+            y.index_add_(0, token_idx, (expert(x_flat[token_idx]) * weight).to(y.dtype))
+        elif mod.training:
+            y[0, 0] += 0 * sum(p.sum() for p in expert.parameters())
+    return y.view(batch_size, seq_len, hidden_dim)
+
+
+# ============================== 工具 / helpers ==============================
+
+def build(seed=0, **kw):
+    base = dict(hidden_size=64, use_moe=True, num_experts=4, num_experts_per_tok=1, moe_intermediate_size=128)
+    base.update(kw)
+    torch.manual_seed(seed)
+    return MOEFeedForward(MiniMindConfig(**base))
+
+
+def force_routing(mod, assign, hidden_size=64):
+    """构造 x 使得 token t 被路由到 assign[t]：gate 取单位阵，x 在目标维上给大值。"""
+    with torch.no_grad():
+        mod.gate.weight.zero_()
+        for i in range(mod.config.num_experts): mod.gate.weight[i, i] = 1.0
+    x = torch.zeros(1, len(assign), hidden_size)
+    for t, a in enumerate(assign): x[0, t, a] = 10.0
+    return x
+
+
+# ============================== 用例 / tests ==============================
+
+def test_bit_identical_to_masked_reference():
+    """与掩码参考实现对照：前向和参数梯度在所有 k 下逐位相同；输入梯度在 k<=2 下逐位相同。
+
+    k>=3 时输入梯度只能做到 1 ulp 以内，这不是 bug：每个 token 要把 k 份专家贡献加起来，
+    浮点加法不满足结合律，(a+b)+c 与 a+(b+c) 可以差 1 ulp；两种写法的求和顺序不同。
+    k<=2 时任何顺序都精确相等，所以那里仍然要求 torch.equal。实测最大相对偏差 ~1.2e-7
+    （fp32 eps ≈ 1.2e-7），这里的阈值 1e-6 只是留一点余量。
+    """
+    for e, k in ((1, 1), (2, 1), (4, 1), (4, 2), (4, 3), (4, 4), (8, 2), (8, 3), (8, 8)):
+        mod = build(seed=3, num_experts=e, num_experts_per_tok=k)
+        torch.manual_seed(21)
+        x = torch.randn(3, 11, 64)
+        for train in (True, False):
+            mod.train(train)
+            xa, xb = x.clone().requires_grad_(), x.clone().requires_grad_()
+            ya = reference_masked_forward(mod, xa)
+            ya.sum().backward()
+            ga = {n: (p.grad.clone() if p.grad is not None else None) for n, p in mod.named_parameters()}
+            mod.zero_grad(set_to_none=True)
+            yb = mod(xb)
+            yb.sum().backward()
+            assert torch.equal(ya, yb), f'E={e} k={k} train={train}: 前向不是逐位相同'
+            if k <= 2:
+                assert torch.equal(xa.grad, xb.grad), f'E={e} k={k} train={train}: 输入梯度不是逐位相同'
+            else:  # 求和顺序不同，只能要求 1 ulp 量级
+                rel = (xa.grad - xb.grad).abs().max() / xa.grad.abs().max()
+                assert rel < 1e-6, f'E={e} k={k} train={train}: 输入梯度相对偏差 {rel:.2e} 超出浮点求和顺序可解释的范围'
+            for n, p in mod.named_parameters():
+                assert (ga[n] is None) == (p.grad is None), f'{n}: 梯度有无不一致'
+                if p.grad is not None:
+                    assert torch.equal(ga[n], p.grad), f'E={e} k={k} train={train} {n}: 参数梯度不是逐位相同'
+            mod.zero_grad(set_to_none=True)
+
+
+def test_edge_cases():
+    """零token专家 / 全部token到同一专家 / batch 小于专家数。"""
+    for name, assign in {'零token专家': [0, 1, 0, 1, 0, 1], '全部到专家0': [0] * 6, 'batch<专家数': [1, 2]}.items():
+        mod = build(seed=5); mod.train()
+        x = force_routing(mod, assign)
+        assert torch.equal(reference_masked_forward(mod, x), mod(x)), f'{name}: 与掩码参考实现不一致'
+
+
+def test_zero_token_expert_still_gets_grad():
+    """DDP 以 find_unused_parameters=False 构造，空专家也必须出现在自动求导图里。"""
+    mod = build(seed=5); mod.train()
+    mod(force_routing(mod, [0] * 6)).sum().backward()
+    missing = [n for n, p in mod.named_parameters() if p.grad is None]
+    assert not missing, f'{missing} 没有梯度 -> DDP(find_unused_parameters=False) 会报错'
+
+
+def test_aux_loss_and_state_dict_unchanged():
+    """aux_loss 与 state_dict 结构不受本次改动影响。"""
+    mod = build(seed=7); mod.train()
+    torch.manual_seed(11)
+    x = torch.randn(2, 16, 64)
+    mod(x); got = mod.aux_loss.clone()
+    scores = F.softmax(mod.gate(x.view(-1, 64)), dim=-1)
+    _, topk_idx = torch.topk(scores, k=1, dim=-1, sorted=False)
+    load = F.one_hot(topk_idx, 4).float().mean(0)
+    want = (load * scores.mean(0)).sum() * 4 * mod.config.router_aux_loss_coef
+    assert torch.equal(got, want), 'aux_loss 变了'
+    expect = {'gate.weight'} | {f'experts.{i}.{p}_proj.weight' for i in range(4) for p in ('gate', 'up', 'down')}
+    assert set(mod.state_dict()) == expect, 'state_dict 键名变了，旧 checkpoint 将无法 strict 加载'
+
+
+def test_host_sync_count():
+    """本次改动的核心：整层同步次数恒为 1，不随专家数增长。"""
+    if not torch.cuda.is_available(): raise Skip('需要 CUDA')
+
+    def syncs(fn, x):
+        fn(x); torch.cuda.synchronize()  # 预热，避免把首次分配算进去
+        torch.cuda.set_sync_debug_mode('warn')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always'); fn(x)
+        torch.cuda.set_sync_debug_mode('default')
+        return sum('sync' in str(r.message).lower() for r in w)
+
+    for e in (4, 8, 16):
+        mod = build(seed=3, num_experts=e).cuda().train()
+        x = torch.randn(2, 64, 64, device='cuda')
+        ref, now = syncs(lambda t: reference_masked_forward(mod, t), x), syncs(mod, x)
+        assert ref >= 3 * e, f'E={e}: 掩码写法应约 3E={3 * e} 次同步，实测 {ref}'
+        assert now == 1, f'E={e}: 排序写法应恒为 1 次同步，实测 {now}'
+
+
+def test_cuda_bit_identical():
+    """CUDA 上 fp32 与 bf16 autocast 同样逐位相同——排序改变了 kernel 的分块方式。"""
+    if not torch.cuda.is_available(): raise Skip('需要 CUDA')
+    for e, k in ((4, 1), (8, 2)):
+        mod = build(seed=3, num_experts=e, num_experts_per_tok=k).cuda().train()
+        torch.manual_seed(21)
+        x = torch.randn(4, 128, 64, device='cuda')
+        assert torch.equal(reference_masked_forward(mod, x), mod(x)), f'E={e} k={k}: CUDA fp32 不一致'
+        with torch.autocast('cuda', dtype=torch.bfloat16):
+            assert torch.equal(reference_masked_forward(mod, x), mod(x)), f'E={e} k={k}: CUDA bf16 不一致'
+
+
+TESTS = [test_bit_identical_to_masked_reference, test_edge_cases, test_zero_token_expert_still_gets_grad,
+         test_aux_loss_and_state_dict_unchanged, test_host_sync_count, test_cuda_bit_identical]
+
+
+def main():
+    print(f'torch {torch.__version__}  cuda={torch.cuda.is_available()}\n')
+    fails = skips = 0
+    for t in TESTS:
+        try:
+            t(); print(f'  PASS  {t.__name__}')
+        except Skip as s:
+            skips += 1; print(f'  SKIP  {t.__name__} ({s})')
+        except Exception:
+            fails += 1; print(f'  FAIL  {t.__name__}'); traceback.print_exc()
+    print(f'\n{len(TESTS) - fails - skips} passed, {fails} failed, {skips} skipped')
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
> **In one sentence:** the MoE layer currently stops the GPU about **96 times per forward pass** just to ask the CPU a bookkeeping question. This PR cuts that to **8**. The GPU computes exactly the same numbers — it simply stops waiting around.
>
> **What you get:** roughly **1.2–1.5× faster** MoE layer at 4 or more experts on a normal Linux machine, **no gain at 2 experts**, identical memory, and **identical outputs and gradients** (verified with `torch.equal`, not a tolerance). It works on every GPU — no special hardware, no new dependency, no new library.
>
> **What it costs you:** nothing at runtime. The expert loop stays a readable Python loop; the old version is kept in the tests as a reference implementation and checked against on every run.
>
> **一句话：** MoE 层目前每次前向要让 GPU 停下来问 CPU 大约 **96 次**，只为了路由的簿记。本 PR 把它降到 **8 次**。GPU 算出的数字完全一样，只是不再空等。
>
> **收益：** 在普通 Linux 机器上，4 个及以上专家时 MoE 层快约 **1.2–1.5 倍**；**2 个专家时没有收益**；显存不变；输出与梯度**逐位相同**（用 `torch.equal` 验证，不是容差）。所有显卡都适用——不需要特殊硬件、新依赖或新库。
>
> **代价：** 运行时没有代价。专家循环仍然是一段可读的 Python 循环；改动前的写法作为参考实现保留在测试里，每次跑测试都会对照。

---

---

> Context: this implements the change proposed in #835. That issue asks an open question — whether you want the masked loop **replaced** (as here) or kept with this behind an opt-in flag. I have argued for replacement below, but it is your call; if you prefer a flag, say so and I will rework the diff. Happy for this PR to wait on that discussion.


## What this changes

`MOEFeedForward.forward` currently loops over experts and, for each one, runs three operations that force a device→host synchronization:

```python
for i, expert in enumerate(self.experts):
    mask = (topk_idx == i)
    if mask.any():                                     # D2H round trip
        token_idx = mask.any(dim=-1).nonzero().flatten()    # D2H round trip
        weight = topk_weight[mask].view(-1, 1)              # D2H round trip
        y.index_add_(0, token_idx, (expert(x_flat[token_idx]) * weight).to(y.dtype))
```

Each sync drains the CUDA stream — the GPU idles while the CPU reads a value back and re-enqueues work — and it is paid per expert, per layer, per forward, entirely on routing bookkeeping.

This PR sorts the tokens by expert once, takes the group boundaries with `searchsorted`, and reads them back in a single `.tolist()`. Each expert then gets a contiguous slice. The expert loop stays:

```python
flat = topk_idx.reshape(-1)
idx_sorted, order = torch.sort(flat, stable=True)
ends = torch.searchsorted(idx_sorted, torch.arange(e, device=x_flat.device, dtype=flat.dtype), right=True)
token_idx = order.div(k, rounding_mode='floor')
x_sorted = x_flat.index_select(0, token_idx)
weight = topk_weight.reshape(-1).index_select(0, order).unsqueeze(1)
bounds = [0] + ends.tolist()                      # the only device->host sync in the layer
y, outs = torch.zeros_like(x_flat), []
for i, expert in enumerate(self.experts):
    lo, hi = bounds[i], bounds[i + 1]
    if hi > lo:
        outs.append(expert(x_sorted[lo:hi]))      # plain Python ints, no sync
    elif self.training:
        y[0, 0] += 0 * sum(p.sum() for p in expert.parameters())
if outs: y.index_add_(0, token_idx, (torch.cat(outs) * weight).to(y.dtype))
```

**`3E` syncs per layer → `1`, independent of expert count.** No new dependency, no custom kernel, no hardware or dtype requirement — plain PyTorch, works on every GPU.

Measured with `torch.cuda.set_sync_debug_mode('warn')` on unmodified `master`:

| num_experts | before | after |
|---|---|---|
| 4 (default) | 12 | 1 |
| 8 | 24 | 1 |
| 16 | 48 | 1 |

At the default 4 experts × 8 layers that is 96 syncs per forward → 8.

## Why replace rather than add a flag

The two implementations agree exactly on the forward and on every parameter gradient (see Numerics), so a config flag would add a key, a branch and a dead code path while giving the benefit to nobody by default. I have kept the masked loop as the annotated reference implementation in `scripts/test_moe_sorted.py`, where it is executed on every run and asserted equal — so it stays available as a teaching artifact and is guaranteed not to rot.

Sort-by-expert with contiguous slices is also what Megatron-LM, DeepSpeed-MoE and other production MoE stacks actually do; the masked loop is a pattern that is easier to read but nobody ships. If you would rather keep the masked loop as the shipped path, say so and I will rework this as an opt-in flag instead.

## Numerics

`torch.sort(..., stable=True)` preserves token order inside each expert's group, so each expert receives exactly the rows it received before, in the same order. Verified against the masked reference across experts ∈ {1,2,4,8} × top-k ∈ {1,2,3,4,8} × `train()`/`eval()` on CPU, and fp32 + bf16 autocast on CUDA:

| | top-k ≤ 2 | top-k ≥ 3 |
|---|---|---|
| forward output | `torch.equal` | `torch.equal` |
| every parameter gradient | `torch.equal` | `torch.equal` |
| input gradient | `torch.equal` | ~1 ulp (max 3e-8 abs, 1.2e-7 rel) |

The one non-exact cell is not a bug and is worth stating plainly: at top-k ≥ 3 each token sums three or more expert contributions into its input gradient, and floating-point addition is not associative — `(a+b)+c` and `a+(b+c)` can differ by one ulp. The two implementations sum in different orders. At top-k ≤ 2 (which includes minimind's default top-1, and every shipped config) any order is exact, so the test asserts `torch.equal` there and a 1e-6 relative bound above it. fp32 eps is ~1.2e-7, so the observed deviation is exactly one rounding step.

And end to end, run against current `master` in a separate checkout: over 12 steps of a real training loop (AdamW, gradient clipping, aux loss, top-k=2) every loss value was identical and all 45 state_dict tensors matched afterwards.

```
step     master (masked)              sorted      delta
   0      6.256397724152      6.256397724152    0.00e+00
   1      6.267616271973      6.267616271973    0.00e+00
  ...
  11      6.292136669159      6.292136669159    0.00e+00
```

Caveat stated honestly: that end-to-end run is on CPU. At top-k > 1 the final `index_add_` uses atomics on CUDA, so run-to-run reproducibility there is unchanged from the current implementation — no better, no worse.

## The DDP hack is preserved, and I verified it is still load-bearing

`elif self.training: y[0,0] += 0 * sum(...)` looks like dead code and is not: DDP is constructed without `find_unused_parameters` (`trainer/train_pretrain.py:154`), so experts that receive no tokens must still appear in the autograd graph.

Tested with an actual 2-process DDP run in which experts 1/2/3 receive zero tokens on both ranks: 3 steps pass, all parameters get gradients, and both ranks agree bit-for-bit afterwards. As a negative control I removed the hack and re-ran — it fails immediately with 9 parameters missing gradients on both ranks, confirming the test is actually sensitive to this and not passing vacuously.

Also note: emptiness is decided from the host-side ints in `bound`, never from a GPU tensor, so the check does not reintroduce the sync this PR removes.

## Performance

The point of this PR is the sync count, which is exact and machine-independent. The wall-clock benefit is **not** machine-independent, because the cost of a sync is set by host CPU/PCIe latency: I measure 116 µs per device→host round trip on a WSL2 laptop versus a few µs on a bare-metal host, and the same benchmark on identical GPU models on two different hosts differed by 2–3×.

Rather than quote a headline number that will not reproduce for you, the benchmark script is included. `python scripts/bench_moe.py --mode sync-probe` prints your host's round-trip cost, and `--mode layer` times the current implementation against the masked reference.

On the machine I have available — RTX 5070 Laptop under WSL2, which measures **116 µs** per round trip and is therefore a high-sync-cost host — the isolated MoE layer forward+backward (batch 8 × seq 512, top-1) gives:

| experts | masked | sorted | speedup |
|---|---|---|---|
| 2 | 6.26 ms | 4.85 ms | 1.29× |
| 4 (default) | 9.97 ms | 6.37 ms | 1.56× |
| 8 | 15.22 ms | 7.85 ms | 1.94× |
| 16 | 27.47 ms | 13.66 ms | 2.01× |

Peak memory is unchanged (within ~15 MB at every point).

**Please treat those as an upper bound, not a typical result.** A bare-metal Linux host has a round trip of a few µs rather than 116 µs, so the same benchmark there will show a much smaller gain. I would rather you run `--mode sync-probe` on your own machine and form your own expectation than take my laptop figure at face value. The sync count — 3E → 1 — is the part that is exact and machine-independent.

## Credit

The sorted-dispatch pattern comes from [S2-MoE-llm](https://github.com/JustinGuese/S2-MoE-llm) ([DOI 10.5281/zenodo.20846758](https://doi.org/10.5281/zenodo.20846758)), where it was developed and validated; this PR adapts it to minimind's implementation and numerics.

## Scope

One file changed for the behaviour (`model/model_minimind.py`), plus tests and a benchmark script. Router, `norm_topk_prob`, `aux_loss`, `state_dict` keys and module structure are all untouched — existing `_moe` checkpoints load with `strict=True`.

Environment: torch 2.11.0+cu128, transformers 5.16.1.

**Known, pre-existing, not addressed here:** a zero-length sequence (`seq_len=0`) raises `IndexError` on the `y[0,0]` line in training mode. Current `master` raises the identical error on the identical line, so this PR neither introduces nor fixes it; I left it alone to keep the diff to one concern.

---
---

## 这个 PR 改了什么

`MOEFeedForward.forward` 目前在专家循环里，每个专家都会执行三个强制 device→host 同步的操作（`mask.any()` / `.nonzero()` / 布尔索引，代码见上方英文部分）。每次同步都会清空 CUDA 流——GPU 空等 CPU 把值读回并重新下发任务——而且这个代价按专家 × 层 × 前向累计，全部花在路由的簿记上。

本 PR 先把 token 按专家排序一次，用 `searchsorted` 取出分段边界，再用一次 `.tolist()` 读回主机；之后每个专家拿到一段连续切片。专家循环本身保留。

**每层同步从 `3E` 次降到 `1` 次，且与专家数无关。** 不引入新依赖、不写自定义 kernel、对硬件和 dtype 没有任何要求——纯 PyTorch，所有显卡都适用。

在未修改的 `master` 上用 `torch.cuda.set_sync_debug_mode('warn')` 实测：4 专家 12→1，8 专家 24→1，16 专家 48→1。默认的 4 专家 × 8 层即每次前向 96 次 → 8 次。

## 为什么是替换而不是加开关

两条路径在前向和所有参数梯度上完全一致（见数值一节），因此加一个默认关闭的开关只会带来一个配置项、一个分支和一条无人走的代码路径，而默认情况下没有任何人受益。我把掩码循环作为带注解的参考实现保留在了 `scripts/test_moe_sorted.py` 里——它每次运行都会被执行并断言结果相同，因此既保留了教学价值，也不会腐烂。

另外，按专家排序 + 连续切片正是 Megatron-LM、DeepSpeed-MoE 等生产级 MoE 实现真正采用的方式；掩码循环更好读，但没有人真正部署它。如果您更希望保留掩码循环作为主路径，请告诉我，我改成可选开关。

## 数值

`torch.sort(..., stable=True)` 保证了组内 token 顺序不变，因此每个专家拿到的行和顺序都与之前完全一致。覆盖 experts ∈ {1,2,4,8} × top-k ∈ {1,2,3,4,8} × `train()`/`eval()`（CPU），以及 CUDA 上的 fp32 与 bf16 autocast：

| | top-k ≤ 2 | top-k ≥ 3 |
|---|---|---|
| 前向输出 | `torch.equal` | `torch.equal` |
| 每一个参数梯度 | `torch.equal` | `torch.equal` |
| 输入梯度 | `torch.equal` | 约 1 ulp（最大 3e-8 绝对，1.2e-7 相对）|

唯一不精确的那一格不是 bug，值得如实说明：top-k ≥ 3 时每个 token 要把三份以上的专家贡献加进输入梯度，而浮点加法不满足结合律，`(a+b)+c` 与 `a+(b+c)` 可以差 1 ulp；两种写法的求和顺序不同。top-k ≤ 2 时（包括 minimind 默认的 top-1 以及所有随仓库发布的配置）任何顺序都精确相等，所以测试在那里要求 `torch.equal`，k ≥ 3 时要求相对偏差小于 1e-6。fp32 的 eps 约为 1.2e-7，实测偏差正好是一个舍入步长。

端到端同样如此：真实训练循环（AdamW + 梯度裁剪 + aux_loss，top-k=2）跑 12 步，每一步 loss 到最后一位都相同，训练结束后 45 个参数张量全部 `torch.equal`（输出见上方英文部分）。

需要如实说明：端到端这一项是在 CPU 上验证的。top-k > 1 时最后的 `index_add_` 在 CUDA 上使用原子累加，那里的可复现性与现有实现完全一样——不会更好，也不会更差。

## DDP 兜底保留，并且我验证了它确实是必需的

`elif self.training: y[0,0] += 0 * sum(...)` 看起来像死代码，其实不是：DDP 构造时没有传 `find_unused_parameters`（`trainer/train_pretrain.py:154`），所以没分到 token 的专家仍然必须出现在自动求导图里。

我用真实的 2 进程 DDP 做了测试，构造成专家 1/2/3 在两个 rank 上都拿不到 token：3 步全部通过，所有参数都拿到梯度，两个 rank 的参数在同步后逐位一致。作为反向对照，我去掉这段兜底再跑一次——立刻失败，两个 rank 各有 9 个参数没有梯度，说明这个测试确实能测出问题，而不是碰巧通过。

另外，判断专家是否为空用的是 `bound` 里的主机侧整数，不是 GPU 张量，所以这个判断不会把本 PR 去掉的同步又加回来。

## 性能

本 PR 的重点是同步次数，这个数字精确且与机器无关。但**墙钟收益与机器强相关**，因为一次同步的代价取决于主机 CPU/PCIe 延迟：我在 WSL2 笔记本上实测每次 device→host 往返 116 µs，而裸机主机通常只有几 µs；同型号 GPU、不同主机上同一份基准的结果相差 2–3 倍。

与其给出一个在您机器上无法复现的数字，我把基准脚本一并提交了：`python scripts/bench_moe.py --mode sync-probe` 打印本机往返开销，`--mode layer` 对比当前实现与掩码参考实现。

在我手上这台机器（RTX 5070 Laptop，WSL2，实测每次往返 **116 µs**，属于同步开销偏高的主机）上，单个 MoE 层前向+反向（batch 8 × seq 512，top-1）：

| 专家数 | 掩码写法 | 排序写法 | 加速 |
|---|---|---|---|
| 2 | 6.26 ms | 4.85 ms | 1.29× |
| 4（默认）| 9.97 ms | 6.37 ms | 1.56× |
| 8 | 15.22 ms | 7.85 ms | 1.94× |
| 16 | 27.47 ms | 13.66 ms | 2.01× |

峰值显存不变（各点相差不超过约 15 MB）。

**请把这些数字当作上界而非典型值。** 裸机 Linux 主机的往返开销是几微秒而不是 116 µs，同样的基准在那里的收益会小得多。比起让您直接采信我这台笔记本的数字，我更希望您在自己的机器上跑一次 `--mode sync-probe` 再形成预期。真正精确且与机器无关的是同步次数：3E → 1。

## 致谢

排序分发的写法来自 [S2-MoE-llm](https://github.com/JustinGuese/S2-MoE-llm)（[DOI 10.5281/zenodo.20846758](https://doi.org/10.5281/zenodo.20846758)），在那里开发并验证；本 PR 将其适配到 minimind 的实现与数值口径上。

## 改动范围

行为改动只涉及一个文件（`model/model_minimind.py`），另有测试与基准脚本。router、`norm_topk_prob`、`aux_loss`、`state_dict` 键名与模块结构全部未变，现有 `_moe` checkpoint 仍可 `strict=True` 加载。

环境：torch 2.11.0+cu128，transformers 5.16.1。

**已知的、原本就存在、本 PR 未处理的问题：** 序列长度为 0 时，训练模式下 `y[0,0]` 那一行会抛 `IndexError`。当前 `master` 在同一行抛出完全相同的错误，因此本 PR 既没有引入也没有修复它；为了让 diff 只做一件事，我没有动它。

