### PR TITLE
perf: enable fused AdamW in SFT & pretrain training

### DIFF
--- a/trainer/train_full_sft.py
+++ b/trainer/train_full_sft.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     train_ds = SFTDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
-    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate, fused=('cuda' in args.device))
     
     # ========== 6. 从ckp恢复状态 ==========
     start_epoch, start_step = 0, 0

--- a/trainer/train_pretrain.py
+++ b/trainer/train_pretrain.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     train_ds = PretrainDataset(args.data_path, tokenizer, max_length=args.max_seq_len)
     train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
     scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
-    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate, fused=(device_type == 'cuda'))
     
     # ========== 6. 从ckp恢复状态 ==========
     start_epoch, start_step = 0, 0


### PR DESCRIPTION
## 变更内容

在 full SFT 训练中启用 PyTorch 的 **fused AdamW** 优化器实现。

```python
optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate, fused=('cuda' in args.device))
```

## 动机

`fused=True` 将 AdamW 的多步更新融合为单个 CUDA kernel,减少 kernel 启动开销,在 CUDA 设备上可明显降低训练 step 耗时;同时按 `args.device` 判断,CPU 回退路径不受影响。

## 测试

- 默认 CPU 路径:`'cuda' in args.device` 为 False,行为与之前一致
- CUDA 路径:使用 fused kernel,等价更新逻辑