### PR TITLE
[fix] 用 AST 求值器替换工具里的 eval()，并修复 Windows 上工具调用全部静默失败

### DIFF
--- a/scripts/eval_toolcall.py
+++ b/scripts/eval_toolcall.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from transformers import AutoTokenizer, AutoModelForCausalLM, TextStreamer
 from openai import OpenAI
 from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
-from trainer.trainer_utils import setup_seed, get_model_params
+from trainer.trainer_utils import setup_seed, get_model_params, safe_math_eval
 warnings.filterwarnings('ignore')
 
 TOOLS = [
@@ -27,7 +27,7 @@ TOOLS = [
 ]
 
 MOCK_RESULTS = {
-    "calculate_math": lambda args: {"result": str(eval(str(args.get("expression", "0")).replace("^", "**").replace("×", "*").replace("÷", "/").replace("−", "-").replace("²", "**2").replace("³", "**3").replace("（", "(").replace("）", ")")))},
+    "calculate_math": lambda args: {"result": str(safe_math_eval(args.get("expression", "0")))},
     "get_current_time": lambda args: {"datetime": datetime.now().strftime("%Y-%m-%d %H:%M:%S"), "timezone": args.get("timezone", "Asia/Shanghai")},
     "random_number": lambda args: {"result": random.randint(int(args.get("min", 0)), int(args.get("max", 100)))},
     "text_length": lambda args: {"characters": len(args.get("text", "")), "words": len(args.get("text", "").split())},

--- a/scripts/web_demo.py
+++ b/scripts/web_demo.py
@@ -2,12 +2,16 @@ import random
 import re
 import json
 import os
+import sys
 from threading import Thread
 
 import torch
 import numpy as np
 import streamlit as st
 from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from trainer.trainer_utils import safe_math_eval
 
 st.set_page_config(page_title="MiniMind", initial_sidebar_state="collapsed")
 
@@ -125,7 +129,7 @@ def execute_tool(tool_name, args):
     import datetime
     try:
         if tool_name == 'calculate_math':
-            return {"result": eval(args.get('expression', '0'))}
+            return {"result": safe_math_eval(args.get('expression', '0'))}
         elif tool_name == 'get_current_time':
             tz = args.get('timezone', 'Asia/Shanghai')
             return {"result": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}

--- a/trainer/train_agent.py
+++ b/trainer/train_agent.py
@@ -10,7 +10,6 @@ import gc
 import json
 import math
 import random
-import signal
 import argparse
 import warnings
 import torch
@@ -24,7 +23,7 @@ from torch.optim.lr_scheduler import CosineAnnealingLR
 from transformers import AutoTokenizer
 from model.model_minimind import MiniMindConfig, MiniMindForCausalLM
 from dataset.lm_dataset import AgentRLDataset
-from trainer.trainer_utils import Logger, is_main_process, lm_checkpoint, init_distributed_mode, setup_seed, SkipBatchSampler, init_model, LMForRewardModel
+from trainer.trainer_utils import Logger, is_main_process, lm_checkpoint, init_distributed_mode, setup_seed, SkipBatchSampler, init_model, LMForRewardModel, safe_math_eval
 from trainer.rollout_engine import create_rollout_engine, compute_per_token_logps
 
 warnings.filterwarnings('ignore')
@@ -55,7 +54,7 @@ UNIT_DATA = {"km_miles": 0.621371, "miles_km": 1.60934, "kg_pounds": 2.20462, "p
 
 # ======== 模拟执行 ========
 MOCK_RESULTS = {
-    "calculate_math": lambda args: {"result": str(eval(str(args.get("expression", "0")).replace("^", "**").replace("×", "*").replace("÷", "/").replace("−", "-").replace("（", "(").replace("）", ")"), {"__builtins__": {}, "math": math}))},
+    "calculate_math": lambda args: {"result": str(safe_math_eval(args.get("expression", "0")))},
     "unit_converter": lambda args: {"result": round(float(args.get("value", 0)) * UNIT_DATA.get(f"{args.get('from_unit', '').lower()}_{args.get('to_unit', '').lower()}", 1), 4)},
     "get_current_weather": lambda args: (lambda w: {"city": args.get("location"), "temperature": w[0], "humidity": "65%", "condition": w[1]})(WEATHER_DATA.get(args.get("location"), ("22°C", "晴"))),
     "get_current_time": lambda args: {"datetime": TIME_DATA.get(args.get("timezone", "Asia/Shanghai"), "2025-03-07 14:30:00"), "timezone": args.get("timezone", "Asia/Shanghai")},
@@ -85,14 +84,9 @@ def execute_tool(name, args):
     fn = MOCK_RESULTS.get(name)
     if not fn: return None
     try:
-        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError()))
-        signal.alarm(1)
         return fn(args)
-    except:
+    except Exception:
         return None
-    finally:
-        try: signal.alarm(0)
-        except: pass
 
 # ======== 多轮 Rollout ========
 def rollout_single(rollout_engine, tokenizer, messages, tools, max_turns=3, max_new_tokens=256, thinking_ratio=0.5, device="cuda"):

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -5,6 +5,8 @@ import os
 import sys
 __package__ = "trainer"
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import ast
+import operator
 import random
 import math
 import numpy as np
@@ -175,3 +177,52 @@ class LMForRewardModel:
         ]
         score = self.model.get_score(self.tokenizer, eval_messages)
         return max(min(score, 3.0), -3.0)
+
+
+# ===== 数学表达式安全求值（替代 eval，避免执行模型生成的任意代码） =====
+_MATH_FUNCS = {name: getattr(math, name) for name in (
+    'sqrt', 'pow', 'exp', 'log', 'log2', 'log10', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'atan2',
+    'sinh', 'cosh', 'tanh', 'floor', 'ceil', 'trunc', 'fabs', 'fmod', 'hypot', 'gcd', 'degrees', 'radians'
+)}
+_MATH_CONSTS = {'pi': math.pi, 'e': math.e, 'tau': math.tau}
+_BIN_OPS = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul, ast.Div: operator.truediv,
+            ast.FloorDiv: operator.floordiv, ast.Mod: operator.mod, ast.Pow: operator.pow}
+_UNARY_OPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+_MAX_EXPR_LEN, _MAX_EXP, _MAX_DIGITS = 512, 1e4, 100  # 表达式长度 / 指数 / 结果位数上限
+
+
+def _check_pow(base, exp):  # 防止 9**9**9 这类表达式把进程算死
+    if abs(exp) > _MAX_EXP or (abs(base) > 1 and abs(exp) * math.log10(abs(base)) > _MAX_DIGITS):
+        raise ValueError('幂运算结果过大')
+
+
+def _resolve_name(node):  # 同时兼容 sqrt(4) 与 math.sqrt(4) 两种写法
+    if isinstance(node, ast.Name): return node.id
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == 'math': return node.attr
+    return None
+
+
+def _eval_ast(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+        return node.value
+    if isinstance(node, (ast.Name, ast.Attribute)) and _resolve_name(node) in _MATH_CONSTS:
+        return _MATH_CONSTS[_resolve_name(node)]
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY_OPS:
+        return _UNARY_OPS[type(node.op)](_eval_ast(node.operand))
+    if isinstance(node, ast.BinOp) and type(node.op) in _BIN_OPS:
+        left, right = _eval_ast(node.left), _eval_ast(node.right)
+        if isinstance(node.op, ast.Pow): _check_pow(left, right)
+        return _BIN_OPS[type(node.op)](left, right)
+    if isinstance(node, ast.Call) and _resolve_name(node.func) in _MATH_FUNCS and not node.keywords:
+        name, args = _resolve_name(node.func), [_eval_ast(arg) for arg in node.args]
+        if name == 'pow' and len(args) == 2: _check_pow(*args)
+        return _MATH_FUNCS[name](*args)
+    raise ValueError(f'不支持的表达式语法: {type(node).__name__}')
+
+
+def safe_math_eval(expression):
+    """对模型生成的数学表达式求值：只放行算术运算与 math 白名单函数，不执行任意代码。"""
+    expr = str(expression).replace('^', '**').replace('×', '*').replace('÷', '/').replace('−', '-')
+    expr = expr.replace('²', '**2').replace('³', '**3').replace('（', '(').replace('）', ')').strip()
+    if not expr or len(expr) > _MAX_EXPR_LEN: raise ValueError('表达式为空或过长')
+    return _eval_ast(ast.parse(expr, mode='eval').body)


### PR DESCRIPTION
Fixes #846

## 问题

1. `execute_tool()` 用 `signal.SIGALRM` 做 1 秒超时，而这是 POSIX-only 的。Windows 上第一行就抛 `AttributeError`，被裸 `except:` 吞掉并 `return None`，导致**每一次工具调用都静默失败**，模型收到的 observation 恒为 `{"error": "tool not found"}`。细节与影响分析见 #846。
2. `calculate_math` 对模型生成的字符串做 `eval()`。三个调用点里有两个**完全没有传 globals**，采样输出可直接触达完整 builtins：

| 调用点 | 修改前 |
|---|---|
| `trainer/train_agent.py:58` | `eval(expr, {"__builtins__": {}, "math": math})` |
| `scripts/eval_toolcall.py:30` | `eval(expr)` — 完整 builtins |
| `scripts/web_demo.py:128` | `eval(expr)` — 完整 builtins |

`web_demo.py` 是会实际暴露给用户的 Streamlit 界面，风险最直接。

## 改动

在 `trainer/trainer_utils.py` 新增 `safe_math_eval()`：用 `ast.parse(mode='eval')` 解析后遍历节点，只放行

- 运算符：`+ - * / // % **` 与一元正负
- 常量：`pi` / `e` / `tau`
- 函数白名单：`sqrt pow exp log log2 log10 sin cos tan asin acos atan atan2 sinh cosh tanh floor ceil trunc fabs fmod hypot gcd degrees radians`

其余节点（`Call` 到非白名单、`Attribute`、`Subscript`、推导式、lambda、赋值……）一律抛 `ValueError`。同时保留原有的字符归一化（`^`→`**`、`×`、`÷`、`−`、`²`、`³`、全角括号），并对表达式长度（512）与幂运算规模（指数 ≤ 1e4 且结果位数 ≤ 100）设上限。

三个调用点统一改为调用它。因为求值过程不可能进入死循环，**基于 signal 的超时不再需要，整段移除**，`execute_tool()` 缩短为 6 行，跨平台行为一致；裸 `except:` 一并收窄为 `except Exception:`。

`sqrt(144)` 与 `math.sqrt(144)` 两种写法都继续可用——前者是 `eval_toolcall.py` 里工具描述所承诺的形式（`如123+456、2**10、sqrt(144)`），但在改动前那个没有 globals 的 `eval` 下其实会抛 `NameError`。

## 验证

Windows 11 / Python 3.12.10 / torch 2.6.0+cu124 / transformers 4.57.6。

改动前（#846 里的复现，所有工具静默返回 None）：

```
has SIGALRM  : False
execute_tool(calculate_math      ) -> None
execute_tool(get_current_time    ) -> None
execute_tool(get_current_weather ) -> None
execute_tool(get_exchange_rate   ) -> None
```

改动后，同一台机器：

```
execute_tool(calculate_math    ) -> {'result': '84'}            # 12*(3+4)
execute_tool(calculate_math    ) -> {'result': '12.0'}          # sqrt(144)
execute_tool(get_current_time  ) -> {'datetime': '2025-03-07 14:30:00', 'timezone': 'Asia/Shanghai'}
execute_tool(get_current_weather) -> {'city': 'Beijing', 'temperature': '22°C', ...}
execute_tool(get_exchange_rate ) -> {'from': 'USD', 'to': 'CNY', 'rate': 7.21}
execute_tool(unit_converter    ) -> {'result': 6.2137}
execute_tool(calculate_math    ) -> None                        # __import__('os').system(...) 被拒
```

求值器本身跑了 21 个正例（含 `2^10`、`3×4`、`（1+2）*3`、`4²`、`log(100, 10)`、`math.pi*2` 等）与 13 个负例（`__import__`、`open`、`().__class__.__bases__`、推导式、lambda、`9**9**9`、`10**99999`、`factorial(999999)`、赋值、import），正例全部数值正确，负例全部拒绝且耗时均 < 0.5s。作为对照，这 13 个负例里的表达式在改动前的 `eval()` 下是可以执行的（抽 4 个无副作用的实测：`eval` 放行 4/4，`safe_math_eval` 放行 0/4）。

## 需要 reviewer 留意的两点

1. `math.factorial` **不在白名单**。它是唯一一个用很短的参数就能把进程算死的 math 函数（`factorial(999999)`），而移除 signal 之后没有兜底，所以直接不放行。改动前它在 `train_agent.py` 里是可达的（`math` 被塞进了 globals），这是一处刻意的能力收窄。
2. `scripts/web_demo.py` 原本没有把仓库根目录加进 `sys.path`，为了 import 这个共用函数补了两行（与 `eval_toolcall.py` 现有写法一致）。

按仓库「极简、从 0 实现」的风格，本 PR 没有新增测试文件与依赖；上面的验证是在本地跑的，如果希望把它固化成一个脚本，我可以另外补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
