### PR TITLE
fix(server): default `stream` to False to comply with OpenAI spec

### DIFF
--- a/scripts/serve_openai_api.py
+++ b/scripts/serve_openai_api.py
@@ -53,7 +53,7 @@ class ChatRequest(BaseModel):
     temperature: float = 0.7
     top_p: float = 0.92
     max_tokens: int = 8192
-    stream: bool = True
+    stream: bool = False  # 对齐 OpenAI 规范：默认非流式，避免标准客户端不传 stream 时误收 SSE
     tools: list = Field(default_factory=list)
     open_thinking: bool = False
     chat_template_kwargs: dict = None


### PR DESCRIPTION
The OpenAI Chat Completions API defaults `stream` to false, but ChatRequest.stream was defaulting to True. As a result, any standard OpenAI-compatible client that omits the `stream` field receives a `text/event-stream` response where it expects plain JSON, and fails with:

    AttributeError: 'str' object has no attribute 'choices'

Reproduce (openai==1.59.6):

    from openai import OpenAI
    c = OpenAI(base_url='http://localhost:8998/v1', api_key='none')
    c.chat.completions.create(model='minimind', messages=[{'role':'user','content':'hi'}])

curl with an explicit "stream": false returns correct JSON, confirming the handler logic is fine and only the default value is at fault.

Explicit `stream=True` requests are unaffected.